### PR TITLE
Enable iOS Builds in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,7 @@ jobs:
   - job: build_macos
     displayName: Build macOS Library
     pool:
-      vmImage: macos-latest
+      vmImage: macos-11
     steps:
       # if this is a tagged build, then update the version number
       - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,10 @@ jobs:
         displayName: 'Build Community Toolkit'
         inputs:
           script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
+      - task: CmdLine@2
+        displayName: 'Build Community Toolkit Sample'
+        inputs:
+          script: 'dotnet build $(PathToSample) -c Release'
       # `dotnet test` does not yet support optional workloads https://github.com/dotnet/sdk/issues/21845#issuecomment-943270826
       - task: CmdLine@2
         displayName: 'Run Unit Tests'
@@ -88,10 +92,6 @@ jobs:
           script: |
             dotnet build $(PathToCommunityToolkitUnitTestCsproj) -c Release
             :: dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release
-      - task: CmdLine@2
-        displayName: 'Build Community Toolkit Sample'
-        inputs:
-          script: 'dotnet build $(PathToSample) -c Release'
       - task: CmdLine@2
         displayName: Pack Community Toolkit NuGets
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,15 +126,15 @@ jobs:
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+        displayName: 'Install .NET SDK'
+        inputs:
+          version: $(NET_VERSION)
+          includePreviewVersions: true    
       - task: CmdLine@2
         displayName: 'Set Xcode Version'
         inputs:
           script: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XcodeVersion).app;sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app/Contents/Developer
             - task: UseDotNet@2
-        displayName: 'Install .NET SDK'
-        inputs:
-          version: $(NET_VERSION)
-          includePreviewVersions: true      
       - task: CmdLine@2
         displayName: 'Install .NET MAUI workload'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,13 @@ jobs:
         displayName: 'Build Community Toolkit'
         inputs:
           script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
+      # `dotnet test` does not yet support optional workloads https://github.com/dotnet/sdk/issues/21845#issuecomment-943270826
+      - task: CmdLine@2
+        displayName: 'Run Unit Tests'
+        inputs:
+          script: |
+            dotnet build $(PathToCommunityToolkitUnitTestCsproj) -c Release
+            :: dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release
       - task: CmdLine@2
         displayName: 'Build Community Toolkit Sample'
         inputs:
@@ -138,13 +145,14 @@ jobs:
       - task: CmdLine@2 # Building iOS + macOS requires a signing certificate
         displayName: 'Build Community Toolkit Android Sample'
         inputs:
-          script: 'dotnet build $(PathToSample) -f net6.0-android -c Release'
-      # Doesn't work yet https://github.com/dotnet/maui/issues/2112
-      # - task: DotNetCoreCLI@2
-      #   displayName: 'Run Unit Tests'
-      #   inputs:
-      #     command: 'test'
-      #     projects: $(PathToCommunityToolkitUnitTestCsproj)
+          script: 'dotnet build $(PathToSample) -c Release'
+      # `dotnet test` does not yet support optional workloads https://github.com/dotnet/sdk/issues/21845#issuecomment-943270826
+      - task: CmdLine@2
+        displayName: 'Run Unit Tests'
+        inputs:
+          script: |
+            dotnet build $(PathToCommunityToolkitUnitTestCsproj) -c Release
+            # dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit NuGets'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,6 +126,7 @@ jobs:
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+      - task: UseDotNet@2
         displayName: 'Install .NET SDK'
         inputs:
           version: $(NET_VERSION)
@@ -134,7 +135,6 @@ jobs:
         displayName: 'Set Xcode Version'
         inputs:
           script: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XcodeVersion).app;sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app/Contents/Developer
-            - task: UseDotNet@2
       - task: CmdLine@2
         displayName: 'Install .NET MAUI workload'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ variables:
   PathToSample: 'samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj'
   PathToCommunityToolkitCsproj: 'src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj'
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj'
+  XcodeVersion: '13.0_beta'
 
 trigger:
   branches:
@@ -125,7 +126,11 @@ jobs:
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-      - task: UseDotNet@2
+      - task: CmdLine@2
+        displayName: 'Set Xcode Version'
+        inputs:
+          script: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XcodeVersion).app;sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app/Contents/Developer
+            - task: UseDotNet@2
         displayName: 'Install .NET SDK'
         inputs:
           version: $(NET_VERSION)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,7 +148,7 @@ jobs:
         inputs:
           script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
       - task: CmdLine@2 # Building iOS + macOS requires a signing certificate
-        displayName: 'Build Community Toolkit Android Sample'
+        displayName: 'Build Community Toolkit Sample'
         inputs:
           script: 'dotnet build $(PathToSample) -c Release'
       # `dotnet test` does not yet support optional workloads https://github.com/dotnet/sdk/issues/21845#issuecomment-943270826

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/MacCatalyst/Info.plist
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/MacCatalyst/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/iOS/Entitlements.plist
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/iOS/Entitlements.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-    </dict>
-</plist>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/iOS/Info.plist
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/iOS/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>14.2</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
## Fixes
Similar PR for `CommunityToolkit.Maui`: https://github.com/CommunityToolkit/Maui/pull/158

This PR allows Azure Pipelines to build the iOS Sample App in `CommunityToolkit.Maui.Markup.Samples`.

## Description

Currently, `azure-pipelines.yml` only builds the Android + MacCatalyst version of the sample app:
```yml
#Note: Building iOS Sample App Requires Provisioning Profile
- task: CmdLine@2
  displayName: 'Build Community Toolkit Sample'
  inputs:
    script: |
      dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f net6.0-android
      dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f net6.0-maccatalyst
```

This was done because building the iOS sample app without a Provisioning Profile would cause an error:
```bash
Build FAILED.

/Users/runner/.dotnet/packs/Microsoft.iOS.Sdk/15.0.101-preview.9.31/tools/msbuild/iOS/Xamarin.Shared.targets(1056,3): error : Could not find any available provisioning profiles
```

By removing `Entitlements.plist`, which is currently empty, we can build the iOS app in Azure Pipelines without the need for a Provisioning Profile 

## Detailed Solution

- Remove `Entitlements.plist`
  - `Entitlements.plist` requires a iOS provisioning profile + iOS signing certificate
- Remove `MinimumOSVersion ` from iOS `Info.plist`
  - Unnecessary due to `SupportedOSPlatformVersion` in the `CommunityToolkit.Maui.Markup.Samples.csproj`
- Remove `LSMinimumSystemVersion` from iOS `Info.plist`
  - Unnecessary due to `SupportedOSPlatformVersion` in the `CommunityToolkit.Maui.Markup.Samples.csproj`
- Set Xcode Version in for Azure Pipelines
  - .NET MAUI currently requires Xcode 13 Beta 5
    ```yml
    - task: CmdLine@2
      displayName: 'Set Xcode Version'
      inputs:
        script: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XcodeVersion).app;sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app/Contents/Developer
      ```
- Update `azure-pipelines.yml` to build the entire Sample App:
  ```yml
  - task: CmdLine@2
   displayName: 'Build Community Toolkit Sample'
   inputs:
     script: 'dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release'
  ```
- Add Steps to Build the Unit Test Project
  - This ensures we do not have build errors on `CommunityToolkit.Maui.Markup.UnitTests`
  - For now, we all comment-out `dotnet test`, because it is still not yet supported bay .NET MAUI: https://github.com/dotnet/sdk/issues/21845#issuecomment-94327082
  - 
    ```yml
    - task: CmdLine@2
      displayName: 'Run Unit Tests'
      inputs:
        script: |
          dotnet build $(PathToCommunityToolkitUnitTestCsproj) -c Release
          # dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release
    ```