### PR TITLE
Add Additional `Style<T>` APIs

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -32,11 +32,11 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 					.LayoutBounds(0.5, 45, 0.8, 40)
 					.Behaviors(new NumericValidationBehavior
 					{
+						Flags = ValidationFlags.ValidateOnValueChanged,
 						MinimumValue = SettingsService.MinimumStoriesToFetch,
 						MaximumValue = SettingsService.MaximumStoriesToFetch,
-						Flags = ValidationFlags.ValidateOnValueChanged,
-						InvalidStyle = new Style<Entry>((Entry.TextColorProperty, Colors.Red)),
-						ValidStyle = new Style<Entry>((Entry.TextColorProperty, ColorConstants.PrimaryTextColor)),
+						InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
+						ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
 					})
 					.Bind(Entry.TextProperty, nameof(SettingsViewModel.NumberOfTopStoriesToFetch))
 					.TextCenter(),
@@ -46,7 +46,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 						Label.TextProperty,
 						binding1: new Binding { Source = SettingsService.MinimumStoriesToFetch },
 						binding2: new Binding { Source = SettingsService.MaximumStoriesToFetch },
-						convert: ((int minimum, int maximum) values) => string.Format(CultureInfo.CurrentUICulture, "The number must be between {0} and {1}.", values.minimum, values.maximum),
+						convert: ((int minimum, int maximum) values) => string.Format(CultureInfo.CurrentUICulture, $"The number must be between {values.minimum} and {values.maximum}."),
 						mode: BindingMode.OneTime)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0, 90, 1, 40)

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -50,9 +50,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 						mode: BindingMode.OneTime)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0, 90, 1, 40)
-					.TextCenter()
-					.TextColor(ColorConstants.PrimaryTextColor)
-					.Font(size: 12, italic: true)
+					.TextCenter().TextColor(ColorConstants.PrimaryTextColor).Font(size: 12, italic: true)
 			}
 		};
 	}

--- a/src/CommunityToolkit.Maui.Markup/Style.cs
+++ b/src/CommunityToolkit.Maui.Markup/Style.cs
@@ -15,9 +15,14 @@ public class Style<T> where T : BindableObject
 	public static implicit operator Style?(Style<T>? style) => style?.FormsStyle;
 
 	/// <summary>
-	/// Style(typeof(T))
+	/// Initialize Style
 	/// </summary>
-	public Style FormsStyle { get; }
+	/// <param name="property">"The <see cref="BindableProperty"/> to style </param>
+	/// <param name="value">"The value for the <see cref="BindableProperty"/> </param>
+	public Style(BindableProperty property, object value) : this((property, value))
+	{
+
+	}
 
 	/// <summary>
 	/// Initialize Style
@@ -28,6 +33,11 @@ public class Style<T> where T : BindableObject
 		FormsStyle = new Style(typeof(T));
 		Add(setters);
 	}
+
+	/// <summary>
+	/// Style(typeof(T))
+	/// </summary>
+	public Style FormsStyle { get; }
 
 	/// <summary>
 	/// Apply to derived types
@@ -54,13 +64,25 @@ public class Style<T> where T : BindableObject
 	/// <summary>
 	/// Add Setters
 	/// </summary>
+	/// <param name="property">"The <see cref="BindableProperty"/> to style </param>
+	/// <param name="value">"The value for the <see cref="BindableProperty"/> </param>
+	/// <returns>Style with added setters</returns>
+	public Style<T> Add(BindableProperty property, object value)
+	{
+		FormsStyle.Setters.Add(property, value);
+		return this;
+	}
+
+	/// <summary>
+	/// Add Setters
+	/// </summary>
 	/// <param name="setters"></param>
 	/// <returns>Style with added setters</returns>
 	public Style<T> Add(params (BindableProperty Property, object Value)[] setters)
 	{
-		foreach (var (Property, Value) in setters)
+		foreach (var (property, value) in setters)
 		{
-			FormsStyle.Setters.Add(Property, Value);
+			Add(property, value);
 		}
 
 		return this;


### PR DESCRIPTION
 ### Description of Change ###

This PR expands on existing `Style<T>` APIs allowing users to more easily add singular style elements by implementing the following updates:
1. Add a second constructor
2. Add an overload for `Add()`

**Existing Constructor**
The existing constructor requires a user to provide a tuple value, even if the user only needs to implement one setter to the style, e.g. 

```cs
public Style(params (BindableProperty Property, object Value)[] setters)
{
  FormsStyle = new Style(typeof(T));
  Add(setters);
}
```

Example
```cs
new Entry().Behaviors(new NumericValidationBehavior
{
  InvalidStyle = new Style<Entry>((Entry.TextColorProperty, Colors.Red)), // Requires superfluous tuple
  ValidStyle = new Style<Entry>((Entry.TextColorProperty, ColorConstants.PrimaryTextColor)), // Requires superfluous tuple
})
```

**Added Constructor** 

The added constructor leverages the existing constructor to allow users to input one `BindableProperty` its value without requiring a tuple

```cs
public Style(BindableProperty property, object value) : this((property, value))
{

}
```

Example
```cs
new Entry().Behaviors(new NumericValidationBehavior
{
  InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red), // No more tuple!
  ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor), // No more tuple!
})
```

**Existing Add() Method**

Similarly, the current `Add()` method requires a tuple even if the user only wants to add one setter:

```cs
public Style<T> Add(params (BindableProperty Property, object Value)[] setters)
{
  foreach (var (property, value) in setters)
  {
    FormsStyle.Setters.Add(property, value);
  }

  return this;
}
```

**Additional Add() Method**

The new additional `Add()` method allows the user to add one setter without needing a superfluous tuple

```cs
public Style<T> Add(BindableProperty property, object value)
{
  FormsStyle.Setters.Add(property, value);
  return this;
}
```

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

- Sample app updated to use new `Style<T>` constructor
 
