### PR TITLE
Support .NET MAUI RC

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,10 +158,12 @@ jobs:
         displayName: 'Set Xcode Version'
         inputs:
           script: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XcodeVersion).app;sudo xcode-select --switch /Applications/Xcode_$(XcodeVersion).app/Contents/Developer
-      - task: UseDotNet@2
-        displayName: 'Install .NET SDK'
+      - task: CmdLine@2
+        displayName: Install .NET 6.0.300-preview.22204.3
         inputs:
-          version: $(NET_VERSION)
+          script: |
+            curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.300-preview.22204.3 --quality preview
+            dotnet --version
       - task: CmdLine@2
         displayName: 'Install .NET MAUI workload'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,14 +44,17 @@ jobs:
     pool:
       vmImage: windows-latest
     steps:
-      - task: UseDotNet@2
-        displayName: 'Install .NET SDK'
-        inputs:
-          version: '$(NET_VERSION)'
+      # - task: UseDotNet@2
+      #   displayName: 'Install .NET SDK'
+      #   inputs:
+      #     version: '$(NET_VERSION)'
       - task: CmdLine@2
-        displayName: 'Install .NET MAUI workload'
+        displayName: 'Install .NET MAUI Workload'
         inputs:
-          script: 'dotnet workload install maui'
+            script : |
+              curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.300-preview.22204.3 --quality preview;
+              dotnet --info;
+              dotnet workload install maui;
       # if this is a tagged build, then update the version number
       - powershell: |
           $buildSourceBranch = "$(Build.SourceBranch)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build Community Toolkit Sample'
         inputs:
-          script: 'dotnet build $(PathToSample) -c Release -f:net6.0-android'
+          script: 'dotnet build $(PathToSample) -c Release'
       # pack
       - task: VSBuild@1
         displayName: 'Build and Pack CommunityToolkit.Maui.Markup'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   PathToSample: 'samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj'
   PathToCommunityToolkitCsproj: 'src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj'
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj'
-  XcodeVersion: '13.3'
+  XcodeVersion: '13.2'
   
 trigger:
   branches:
@@ -103,7 +103,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build Community Toolkit Sample'
         inputs:
-          script: 'dotnet build $(PathToSample) -c Release'
+          script: 'dotnet build $(PathToSample) -c Release -f:net6.0-android'
       # pack
       - task: VSBuild@1
         displayName: 'Build and Pack CommunityToolkit.Maui.Markup'
@@ -184,7 +184,7 @@ jobs:
       - task: CmdLine@2 # Building iOS + macOS requires a signing certificate
         displayName: 'Build Community Toolkit Sample'
         inputs:
-          script: 'dotnet build $(PathToSample) -c Release'
+          script: 'dotnet build $(PathToSample) -c Release -f:net6.0-android'
       - task: CmdLine@2
         displayName: 'Run Unit Tests'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,7 +149,7 @@ jobs:
   - job: build_macos
     displayName: Build macOS Library
     pool:
-      vmImage: macos-12
+      vmImage: macos-latest
     steps:
       # if this is a tagged build, then update the version number
       - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,17 +44,19 @@ jobs:
     pool:
       vmImage: windows-latest
     steps:
-      # - task: UseDotNet@2
-      #   displayName: 'Install .NET SDK'
-      #   inputs:
-      #     version: '$(NET_VERSION)'
+      - powershell: |
+             wget https://dot.net/v1/dotnet-install.ps1 -OutFile C:\dotnet-install.ps1
+             C:\dotnet-install.ps1 -Version 6.0.300-preview.22204.3
+             dotnet --info
+             Write-Host "##vso[task.prependpath]C:\\Users\\VssAdministrator\\AppData\\Local\\Microsoft\\dotnet"
+        displayName: Install .NET 6.0.300-preview.22204.3
       - task: CmdLine@2
         displayName: 'Install .NET MAUI Workload'
         inputs:
             script : |
-              curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.300-preview.22204.3 --quality preview;
-              dotnet --info;
-              dotnet workload install maui;
+              dotnet --info
+              dotnet workload install maui
+              dotnet new globaljson --sdk-version 6.0.300-preview.22204.3 --force
       # if this is a tagged build, then update the version number
       - powershell: |
           $buildSourceBranch = "$(Build.SourceBranch)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
   PathToSample: 'samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj'
   PathToCommunityToolkitCsproj: 'src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj'
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj'
-  XcodeVersion: '13.2'
+  XcodeVersion: '13.3'
   
 trigger:
   branches:
@@ -149,7 +149,7 @@ jobs:
   - job: build_macos
     displayName: Build macOS Library
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
       # if this is a tagged build, then update the version number
       - powershell: |

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.*",
-    "rollForward": "patch",
+    "version": "6.0.300-preview.22204.3",
+    "rollForward": "latestMajor",
     "allowPrerelease": true
   }
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
@@ -46,7 +46,6 @@
 	<ItemGroup>
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Refit" Version="6.3.2" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre8" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
 	</ItemGroup>
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks> 
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>CommunityToolkit.Maui.Markup.Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -14,15 +14,14 @@
 
 		<!-- App Identifier -->
 		<ApplicationId>com.CommunityToolkit.MarkupSample</ApplicationId>
-        <ApplicationId Condition="$(TargetFramework.Contains('-windows'))">1F9C3A44-059B-4FBC-9D92-476E59FB937A</ApplicationId>
+		<ApplicationId Condition="$(TargetFramework.Contains('-windows'))">1F9C3A44-059B-4FBC-9D92-476E59FB937A</ApplicationId>
 
-        <!-- Versions -->
-        <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+		<!-- Versions -->
+		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<!-- Required for C# Hot Reload -->
 		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
-
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
@@ -45,19 +44,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Refit" Version="6.3.2" />
+		<PackageReference Include="Polly" Version="7.2.3" />
+		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre8" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
-    </ItemGroup>
+	</ItemGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<OutputType>WinExe</OutputType>
 		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 	</PropertyGroup>
-
 </Project>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -45,21 +45,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Polly" Version="7.2.3" />
-        <PackageReference Include="Refit" Version="6.3.2" />
-				<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre8" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview2" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Refit" Version="6.3.2" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre8" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
     </ItemGroup>
-
-	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-		<!-- Required - WinUI does not yet have buildTransitive for everything -->
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
-		<PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.30" />
-	</ItemGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
 		<OutputType>WinExe</OutputType>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -21,7 +21,6 @@
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<!-- Required for C# Hot Reload -->
-		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
@@ -52,9 +51,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
 	</ItemGroup>
-
-	<PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
-		<OutputType>WinExe</OutputType>
-		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
-	</PropertyGroup>
 </Project>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -7,7 +7,6 @@
 		<RootNamespace>CommunityToolkit.Maui.Markup.Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
-		<EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
 
 		<!-- Display name -->
 		<ApplicationTitle>Sample</ApplicationTitle>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -2,10 +2,10 @@
 using CommunityToolkit.Maui.Markup.Sample.Services;
 using CommunityToolkit.Maui.Markup.Sample.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls.Hosting;
-using Microsoft.Maui.Essentials;
-using Microsoft.Maui.Essentials.Implementations;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Storage;
 using Refit;
 
 namespace CommunityToolkit.Maui.Markup.Sample;
@@ -20,8 +20,8 @@ public class MauiProgram
 								.UseMauiCommunityToolkitMarkup();
 
 		// Maui.Essentials
-		builder.Services.AddSingleton<IBrowser, BrowserImplementation>();
-		builder.Services.AddSingleton<IPreferences, PreferencesImplementation>();
+		builder.Services.AddSingleton(Browser.Default);
+		builder.Services.AddSingleton(Preferences.Default);
 
 		// Services
 		builder.Services.AddSingleton<App>();

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -16,7 +16,7 @@ public class MauiProgram
 	{
 		var builder = MauiApp.CreateBuilder()
 								.UseMauiApp<App>()
-								.UseMauiCommunityToolkit()
+								//.UseMauiCommunityToolkit() // Temporarily removed until CommunityToolkit.Maui v1.0.0-pre9 is available
 								.UseMauiCommunityToolkitMarkup();
 
 		// Maui.Essentials

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
@@ -8,9 +8,9 @@ using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.ViewModels;
 using CommunityToolkit.Maui.Markup.Sample.Views.News;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
-using Microsoft.Maui.Essentials;
 using Microsoft.Maui.Graphics;
 
 namespace CommunityToolkit.Maui.Markup.Sample.Pages;

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Markup.Sample.Constants;
 using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.Services;
@@ -34,14 +33,15 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 					.Placeholder($"Provide a value between {SettingsService.MinimumStoriesToFetch} and {SettingsService.MaximumStoriesToFetch}", Colors.Grey)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0.5, 45, 0.8, 40)
-					.Behaviors(new NumericValidationBehavior
-					{
-						Flags = ValidationFlags.ValidateOnValueChanged,
-						MinimumValue = SettingsService.MinimumStoriesToFetch,
-						MaximumValue = SettingsService.MaximumStoriesToFetch,
-						InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
-						ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
-					})
+					// Temporarily remove this until CommunityTookit.Maui v1.0.0-pre9 is released
+					//.Behaviors(new NumericValidationBehavior
+					//{
+					//	Flags = ValidationFlags.ValidateOnValueChanged,
+					//	MinimumValue = SettingsService.MinimumStoriesToFetch,
+					//	MaximumValue = SettingsService.MaximumStoriesToFetch,
+					//	InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
+					//	ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
+					//})
 					.Bind(Entry.TextProperty, nameof(SettingsViewModel.NumberOfTopStoriesToFetch))
 					.TextCenter(),
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
@@ -23,11 +23,4 @@ public partial class App : MauiWinUIApplication
 	}
 
 	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
-
-	protected override void OnLaunched(LaunchActivatedEventArgs args)
-	{
-		base.OnLaunched(args);
-
-		Microsoft.Maui.Essentials.Platform.OnLaunched(args);
-	}
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Services/SettingsService.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Services/SettingsService.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Microsoft.Maui.Essentials;
+using Microsoft.Maui.Storage;
 
 namespace CommunityToolkit.Maui.Markup.Sample.Services;
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/NewsViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/NewsViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Maui.Markup.Sample.Services;
 using CommunityToolkit.Maui.Markup.Sample.ViewModels.Base;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
 


### PR DESCRIPTION
 ### Description of Change ###

This PR adds support for .NET MAUI RC:
- Update CI Pipeline to use `6.0.300-preview.22204.3`
- Update `global.json` to use `6.0.300-preview.22204.3`
- Remove Windows-specific NuGet Packages
  - Recommended in .NET MAUI's [Migrating-to-RC1](https://github.com/dotnet/maui/wiki/Migrating-to-RC1) docs
- Update Legacy Maui.Essentials Namespaces
- Temporarily Update `Build Sample App` step to only build `net6.0-android`
  - Building `net6.0-ios` and `net6.0-maccatalyst` requires Xcode 13.3.1 which is not currently available on Azure Pipelines

### Additional Information

We will need to update `CommunityToolkit.Maui.Markup.Sample` to use `CommunityToolkit.Maui v1.0.0-pre9` once the `CommunityToolkit.Maui` NuGet package has been released.

We will also need to remove `-f:net6.0-android` from the `Build Sample App` step once Xcode 13.3.1 is available in Azure Pipelines.