### PR TITLE
Re-Add `CommunityToolkit.Maui` to Sample App

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -45,6 +45,7 @@
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -16,7 +16,7 @@ public class MauiProgram
 	{
 		var builder = MauiApp.CreateBuilder()
 								.UseMauiApp<App>()
-								//.UseMauiCommunityToolkit() // Temporarily removed until CommunityToolkit.Maui v1.0.0-pre9 is available
+								.UseMauiCommunityToolkit()
 								.UseMauiCommunityToolkitMarkup();
 
 		// Maui.Essentials

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Markup.Sample.Constants;
 using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.Services;
@@ -33,7 +34,6 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 					.Placeholder($"Provide a value between {SettingsService.MinimumStoriesToFetch} and {SettingsService.MaximumStoriesToFetch}", Colors.Grey)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0.5, 45, 0.8, 40)
-					/* Temporarily remove this until CommunityTookit.Maui v1.0.0-pre9 is released
 					.Behaviors(new NumericValidationBehavior
 					{
 						Flags = ValidationFlags.ValidateOnValueChanged,
@@ -41,7 +41,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 						MaximumValue = SettingsService.MaximumStoriesToFetch,
 						InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
 						ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
-					}) */
+					})
 					.Bind(Entry.TextProperty, nameof(SettingsViewModel.NumberOfTopStoriesToFetch))
 					.TextCenter(),
 


### PR DESCRIPTION
 ### Description of Change ###

This PR re-adds the `CommunityToolkit.Maui` NuGet Package to `CommunityToolkit.Maui.Markup.Sample`.

Version 1.0.0-pre8 of this NuGet package had been temporarily removed after updating to .NET MAUI RC because of breaking changes in the Release Candidate.

Now that CommunityToolkit.Maui v1.0.0-pre9 (which targets .NET MAUI RC) has been published, we can add it back into the Sample App.
 
