### PR TITLE
Fix `.Text()` Bug

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
@@ -32,11 +32,7 @@ class NewsPage : BaseContentPage<NewsViewModel>
 
 		BindingContext.PullToRefreshFailed += HandlePullToRefreshFailed;
 
-		ToolbarItems.Add(new ToolbarItem
-		{
-			Command = new AsyncRelayCommand(ShowSettings, true),
-			Text = "Settings"
-		});
+		ToolbarItems.Add(new ToolbarItem { Command = new AsyncRelayCommand(ShowSettings, true) }.Text("Settings"));
 
 		Content = new RefreshView
 		{

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ElementExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ElementExtensionsTests.cs
@@ -84,43 +84,6 @@ class ElementExtensionsTests : BaseMarkupTestFixture<Label>
 	public void FontWithFamilyNamedParameter()
 		=> TestPropertiesSet(l => l.Font(family: "AFontName"), (FontElement.FontFamilyProperty, string.Empty, "AFontName"));
 
-	[Test]
-	public void TextColor_ProvidedColor()
-		=> TestPropertiesSet(l => l.TextColor(Colors.Red), (TextElement.TextColorProperty, Colors.Red));
-
-	[Test]
-	public void TextColor_CustomColor()
-		=> TestPropertiesSet(l => l.TextColor(new Color(0.124f, 0.654f, 0.9234f, 0.100f)), (TextElement.TextColorProperty, new Color(0.124f, 0.654f, 0.9234f, 0.100f)));
-
-	[Test]
-	public void Text_NoColor()
-		=> TestPropertiesSet(l => l.Text("Hello World"), (Label.TextProperty, "Hello World"));
-
-	[Test]
-	public void Text_ProvidedColor()
-		=> TestPropertiesSet(l => l.Text("Hello World", Colors.Green), (Label.TextProperty, "Hello World"), (TextElement.TextColorProperty, Colors.Green));
-
-	[Test]
-	public void Text_CustomColor()
-		=> TestPropertiesSet(l => l.Text("Hello World", new Color(250, 5, 128, 1)), (Label.TextProperty, "Hello World"), (TextElement.TextColorProperty, new Color(250, 5, 128, 1)));
-
-	[Test]
-	public void Text_NullValues()
-		=> TestPropertiesSet(l => l.Text(null, null), (Label.TextProperty, null), (TextElement.TextColorProperty, null));
-
-	[Test]
-	public void SupportDerivedFromLabel()
-	{
-		Assert.IsInstanceOf<DerivedFromLabel>(
-			new DerivedFromLabel()
-			.Effects(new NullEffect())
-			.FontSize(8)
-			.Bold()
-			.Italic()
-			.Text("Hello World", new Color(255, 255, 128, 1))
-			.Font("AFontName", 8, true, true));
-	}
-
 	static Label AssertDynamicResources()
 	{
 		var label = new Label { Resources = new ResourceDictionary { { "TextKey", "TextValue" }, { "ColorKey", Colors.Green } } };
@@ -135,9 +98,5 @@ class ElementExtensionsTests : BaseMarkupTestFixture<Label>
 		Assert.That(label.TextColor, Is.EqualTo(Colors.Green));
 
 		return label;
-	}
-
-	class DerivedFromLabel : Label
-	{
 	}
 }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextTests.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using CommunityToolkit.Maui.Markup.UnitTests.Base;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using NUnit.Framework;
+
+namespace CommunityToolkit.Maui.Markup.UnitTests;
+
+class LabelTextTests : BaseMarkupTestFixture<Label>
+{
+	[Test]
+	public void LabelTextColor_ProvidedColor()
+		=> TestPropertiesSet(l => l.TextColor(Colors.Red), (TextElement.TextColorProperty, Colors.Red));
+
+	[Test]
+	public void LabelTextColor_CustomColor()
+		=> TestPropertiesSet(l => l.TextColor(new Color(0.124f, 0.654f, 0.9234f, 0.100f)), (TextElement.TextColorProperty, new Color(0.124f, 0.654f, 0.9234f, 0.100f)));
+
+	[Test]
+	public void LabelText_NoColor()
+		=> TestPropertiesSet(l => l.Text("Hello World"), (Label.TextProperty, "Hello World"));
+
+	[Test]
+	public void LabelText_ProvidedColor()
+		=> TestPropertiesSet(l => l.Text("Hello World", Colors.Green), (Label.TextProperty, "Hello World"), (TextElement.TextColorProperty, Colors.Green));
+
+	[Test]
+	public void LabelText_CustomColor()
+		=> TestPropertiesSet(l => l.Text("Hello World", new Color(250, 5, 128, 1)), (Label.TextProperty, "Hello World"), (TextElement.TextColorProperty, new Color(250, 5, 128, 1)));
+
+	[Test]
+	public void SupportDerivedFromLabel()
+	{
+		Assert.IsInstanceOf<DerivedFromLabel>(
+			new DerivedFromLabel()
+			.Effects(new NullEffect())
+			.FontSize(8)
+			.Bold()
+			.Italic()
+			.Text("Hello World", new Color(255, 255, 128, 1))
+			.Font("AFontName", 8, true, true));
+	}
+
+	class DerivedFromLabel : Label
+	{
+	}
+}
+
+class ButtonTextTests : BaseMarkupTestFixture<Button>
+{
+	[Test]
+	public void ButtonTextColor_ProvidedColor()
+		=> TestPropertiesSet(b => b.TextColor(Colors.Red), (TextElement.TextColorProperty, Colors.Red));
+
+	[Test]
+	public void ButtonTextColor_CustomColor()
+		=> TestPropertiesSet(b => b.TextColor(new Color(0.124f, 0.654f, 0.9234f, 0.100f)), (TextElement.TextColorProperty, new Color(0.124f, 0.654f, 0.9234f, 0.100f)));
+
+	[Test]
+	public void ButtonText_NoColor()
+		=> TestPropertiesSet(b => b.Text("Hello World"), (Button.TextProperty, "Hello World"));
+
+	[Test]
+	public void ButtonText_ProvidedColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", Colors.Green), (Button.TextProperty, "Hello World"), (TextElement.TextColorProperty, Colors.Green));
+
+	[Test]
+	public void ButtonText_CustomColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", new Color(250, 5, 128, 1)), (Button.TextProperty, "Hello World"), (TextElement.TextColorProperty, new Color(250, 5, 128, 1)));
+
+	[Test]
+	public void SupportDerivedFromButton()
+	{
+		Assert.IsInstanceOf<DerivedFromButton>(
+			new DerivedFromButton()
+			.Effects(new NullEffect())
+			.FontSize(8)
+			.Bold()
+			.Italic()
+			.Text("Hello World", new Color(255, 255, 128, 1))
+			.Font("AFontName", 8, true, true));
+	}
+
+	class DerivedFromButton : Button
+	{
+	}
+}
+
+class MenuItemTextTests : BaseMarkupTestFixture<MenuItem>
+{
+	[Test]
+	public void MenuItemTextColor_ProvidedColor()
+		=> Assert.Throws<NotSupportedException>(() => Bindable.TextColor(Colors.Teal));
+
+	[Test]
+	public void ButtonText_NoColor()
+		=> TestPropertiesSet(b => b.Text("Hello World"), (MenuItem.TextProperty, "Hello World"));
+
+	[Test]
+	public void ButtonText_ProvidedColor()
+		=> Assert.Throws<NotSupportedException>(() => Bindable.Text("Hello World", Colors.Green));
+
+	[Test]
+	public void SupportDerivedFromButton()
+	{
+		Assert.IsInstanceOf<DerivedFromMenuItem>(
+			new DerivedFromMenuItem()
+			.Effects(new NullEffect())
+			.Text("Hello World"));
+	}
+
+	class DerivedFromMenuItem : MenuItem
+	{
+	}
+}
+
+class EditorTextTests : BaseMarkupTestFixture<Editor>
+{
+	[Test]
+	public void EditorTextColor_ProvidedColor()
+		=> TestPropertiesSet(b => b.TextColor(Colors.Red), (TextElement.TextColorProperty, Colors.Red));
+
+	[Test]
+	public void EditorTextColor_CustomColor()
+		=> TestPropertiesSet(b => b.TextColor(new Color(0.124f, 0.654f, 0.9234f, 0.100f)), (TextElement.TextColorProperty, new Color(0.124f, 0.654f, 0.9234f, 0.100f)));
+
+	[Test]
+	public void EditorText_NoColor()
+		=> TestPropertiesSet(b => b.Text("Hello World"), (Editor.TextProperty, "Hello World"));
+
+	[Test]
+	public void EditorText_ProvidedColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", Colors.Green), (Editor.TextProperty, "Hello World"), (TextElement.TextColorProperty, Colors.Green));
+
+	[Test]
+	public void EditorText_CustomColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", new Color(250, 5, 128, 1)), (Editor.TextProperty, "Hello World"), (TextElement.TextColorProperty, new Color(250, 5, 128, 1)));
+
+	[Test]
+	public void SupportDerivedFromEnditor()
+	{
+		Assert.IsInstanceOf<DerivedFromEditor>(
+			new DerivedFromEditor()
+			.Effects(new NullEffect())
+			.FontSize(8)
+			.Bold()
+			.Italic()
+			.Text("Hello World", new Color(255, 255, 128, 1))
+			.Font("AFontName", 8, true, true));
+	}
+
+	class DerivedFromEditor : Editor
+	{
+	}
+}
+
+class EntryTextTests : BaseMarkupTestFixture<Entry>
+{
+	[Test]
+	public void EntryTextColor_ProvidedColor()
+		=> TestPropertiesSet(b => b.TextColor(Colors.Red), (TextElement.TextColorProperty, Colors.Red));
+
+	[Test]
+	public void EntryTextColor_CustomColor()
+		=> TestPropertiesSet(b => b.TextColor(new Color(0.124f, 0.654f, 0.9234f, 0.100f)), (TextElement.TextColorProperty, new Color(0.124f, 0.654f, 0.9234f, 0.100f)));
+
+	[Test]
+	public void EntryText_NoColor()
+		=> TestPropertiesSet(b => b.Text("Hello World"), (Entry.TextProperty, "Hello World"));
+
+	[Test]
+	public void EntryText_ProvidedColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", Colors.Green), (Entry.TextProperty, "Hello World"), (TextElement.TextColorProperty, Colors.Green));
+
+	[Test]
+	public void EntryText_CustomColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", new Color(250, 5, 128, 1)), (Entry.TextProperty, "Hello World"), (TextElement.TextColorProperty, new Color(250, 5, 128, 1)));
+
+	[Test]
+	public void SupportDerivedFromEntry()
+	{
+		Assert.IsInstanceOf<DerivedFromEntry>(
+			new DerivedFromEntry()
+			.Effects(new NullEffect())
+			.FontSize(8)
+			.Bold()
+			.Italic()
+			.Text("Hello World", new Color(255, 255, 128, 1))
+			.Font("AFontName", 8, true, true));
+	}
+
+	class DerivedFromEntry : Entry
+	{
+	}
+}
+
+class SearchBarTextTests : BaseMarkupTestFixture<SearchBar>
+{
+	[Test]
+	public void SearchBarTextColor_ProvidedColor()
+		=> TestPropertiesSet(b => b.TextColor(Colors.Red), (TextElement.TextColorProperty, Colors.Red));
+
+	[Test]
+	public void SearchBarTextColor_CustomColor()
+		=> TestPropertiesSet(b => b.TextColor(new Color(0.124f, 0.654f, 0.9234f, 0.100f)), (TextElement.TextColorProperty, new Color(0.124f, 0.654f, 0.9234f, 0.100f)));
+
+	[Test]
+	public void SearchBarText_NoColor()
+		=> TestPropertiesSet(b => b.Text("Hello World"), (SearchBar.TextProperty, "Hello World"));
+
+	[Test]
+	public void SearchBarText_ProvidedColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", Colors.Green), (SearchBar.TextProperty, "Hello World"), (TextElement.TextColorProperty, Colors.Green));
+
+	[Test]
+	public void SearchBarText_CustomColor()
+		=> TestPropertiesSet(b => b.Text("Hello World", new Color(250, 5, 128, 1)), (SearchBar.TextProperty, "Hello World"), (TextElement.TextColorProperty, new Color(250, 5, 128, 1)));
+
+	[Test]
+	public void SupportDerivedFromSearchBar()
+	{
+		Assert.IsInstanceOf<DerivedFromSearchBar>(
+			new DerivedFromSearchBar()
+			.Effects(new NullEffect())
+			.FontSize(8)
+			.Bold()
+			.Italic()
+			.Text("Hello World", new Color(255, 255, 128, 1))
+			.Font("AFontName", 8, true, true));
+	}
+
+	class DerivedFromSearchBar : SearchBar
+	{
+	}
+}

--- a/src/CommunityToolkit.Maui.Markup/ElementExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ElementExtensions.cs
@@ -184,7 +184,13 @@ public static class ElementExtensions
 	/// <returns></returns>
 	public static TBindable TextColor<TBindable>(this TBindable bindable, Color? textColor) where TBindable : BindableObject, ITextStyle
 	{
+		if (bindable is MenuItem)
+		{
+			throw new NotSupportedException($"{typeof(MenuItem)} is not supported");
+		}
+
 		bindable.SetValue(TextElement.TextColorProperty, textColor);
+
 		return bindable;
 	}
 

--- a/src/CommunityToolkit.Maui.Markup/ElementExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ElementExtensions.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Maui;
+﻿using System;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Internals;
 using Microsoft.Maui.Graphics;
-using ITextElement = Microsoft.Maui.Controls.Label; // ToDo Remove this once TextElement.TextProperty is added
 
 namespace CommunityToolkit.Maui.Markup;
 
@@ -197,7 +197,36 @@ public static class ElementExtensions
 	/// <returns></returns>
 	public static TBindable Text<TBindable>(this TBindable bindable, string? text) where TBindable : BindableObject, IText
 	{
-		bindable.SetValue(ITextElement.TextProperty, text);
+		switch (bindable)
+		{
+			case ILabel:
+				bindable.SetValue(Label.TextProperty, text);
+				break;
+
+			case IButton:
+				bindable.SetValue(Button.TextProperty, text);
+				break;
+
+			case MenuItem:
+				bindable.SetValue(MenuItem.TextProperty, text);
+				break;
+
+			case IEditor:
+				bindable.SetValue(Editor.TextProperty, text);
+				break;
+
+			case IEntry:
+				bindable.SetValue(Entry.TextProperty, text);
+				break;
+
+			case ISearchBar:
+				bindable.SetValue(SearchBar.TextProperty, text);
+				break;
+
+			default:
+				throw new NotSupportedException($"{typeof(TBindable)} is not supported");
+		};
+
 		return bindable;
 	}
 


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes the `InvalidCastException` that is currently thrown by `.Text()` when used on the following Controls:
- `IButton`
- `MenuItem` (there is no `IMenuItem`)
- `IEditor`
- `IEntry`
- `ISearchBar`

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #55 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This is a temporary work-around that accommodates all of the current `IText` controls in .NET MAUI.

The proper solution is to create a Source Generator that generates a control-specific method for each `IText` control, similar to how we implemented the [`TextColorToGenerator` in CommunityToolkit.Maui](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs). The source generator would ensure that `.Text()` works for all future `IText` controls in .NET MAUI as well as custom `IText` controls created by users.
