### PR TITLE
Enable Support for .NET MAUI RC2

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -45,7 +45,6 @@
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -16,7 +16,7 @@ public class MauiProgram
 	{
 		var builder = MauiApp.CreateBuilder()
 								.UseMauiApp<App>()
-								.UseMauiCommunityToolkit()
+								// .UseMauiCommunityToolkit() // Temporarily remove CommunityToolkit.Maui-rc1 until CommunityToolkit.Maui-rc2 is available
 								.UseMauiCommunityToolkitMarkup();
 
 		// Fonts

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Markup.Sample.Constants;
 using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.Services;
@@ -34,6 +33,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 					.Placeholder($"Provide a value between {SettingsService.MinimumStoriesToFetch} and {SettingsService.MaximumStoriesToFetch}", Colors.Grey)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0.5, 45, 0.8, 40)
+					/* Temporarily remove CommunityToolkit.Maui-rc1 until CommunityToolkit.Maui-rc2 is available
 					.Behaviors(new NumericValidationBehavior
 					{
 						Flags = ValidationFlags.ValidateOnValueChanged,
@@ -42,6 +42,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 						InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
 						ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
 					})
+					*/
 					.Bind(Entry.TextProperty, nameof(SettingsViewModel.NumberOfTopStoriesToFetch))
 					.TextCenter(),
 


### PR DESCRIPTION
 ### Description of Change ###

This PR updates `CommunityToolkit.Maui.Markup` to support [.NET MAUI RC2](https://github.com/dotnet/maui/releases/tag/6.0.300-rc.2).

 ### Additional information ###

This PR includes the following changes:
- Updates `CommunityToolkit.Maui.Markup.Sample` app
  - Temporarily removes `CommunityToolkit.Maui` NuGet package until `CommunityToolkit.Maui-rc2` is released
 
