### PR TITLE
Update Sample App for .NET MAUI RC 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,8 @@ variables:
   NET_VERSION: '6.0.x'
   RunPoliCheck: 'false'
   PathToSolution: 'src/CommunityToolkit.Maui.Markup.sln'
-  PathToSample: 'samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj'
   PathToCommunityToolkitCsproj: 'src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj'
+  PathToCommunityToolkitSampleCsproj: 'samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj'
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj'
   XcodeVersion: '13.3.1'
   
@@ -96,14 +96,12 @@ jobs:
           summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
           failIfCoverageEmpty: true
       # build sample
-      - task: CmdLine@2
-        displayName: 'Build Community Toolkit'
+      - task: VSBuild@1
+        displayName: 'Build Markup Community Toolkit Sample'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
-      - task: CmdLine@2
-        displayName: 'Build Community Toolkit Sample'
-        inputs:
-          script: 'dotnet build $(PathToSample) -c Release'
+          solution: '$(PathToCommunityToolkitSampleCsproj)'
+          configuration: 'Release'
+          msbuildArgs: '/restore'
       # pack
       - task: VSBuild@1
         displayName: 'Build and Pack CommunityToolkit.Maui.Markup'
@@ -185,7 +183,7 @@ jobs:
       - task: CmdLine@2 # Building iOS + macOS requires a signing certificate
         displayName: 'Build Community Toolkit Sample'
         inputs:
-          script: 'dotnet build $(PathToSample) -c Release -f:net6.0-android' # Remove -f:net6.0-android once Xcode 13.3.1 is available on Azure Pipelines (required for .NET MAUI RC)
+          script: 'dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f:net6.0-android' # Remove -f:net6.0-android once Xcode 13.3.1 is available on Azure Pipelines (required for .NET MAUI RC)
       - task: CmdLine@2
         displayName: 'Run Unit Tests'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
           failIfCoverageEmpty: true
       # build sample
       - task: VSBuild@1
-        displayName: 'Build Markup Community Toolkit Sample'
+        displayName: 'Build Markup CommunityToolkit.Maui.Markup.Sample'
         inputs:
           solution: '$(PathToCommunityToolkitSampleCsproj)'
           configuration: 'Release'

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -45,7 +45,6 @@
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Refit" Version="6.3.2" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-pre9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -28,16 +28,20 @@
 
 	<ItemGroup>
 		<!-- App Icon -->
-		<MauiImage Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" IsAppIcon="true" Color="#512BD4" />
+		<MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" />
+		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
 		<MauiImage Include="Resources\Images\*" />
+		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />
+
+		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>CommunityToolkit.Maui.Markup.Sample</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -13,18 +13,17 @@
 
 		<!-- App Identifier -->
 		<ApplicationId>com.CommunityToolkit.MarkupSample</ApplicationId>
-		<ApplicationId Condition="$(TargetFramework.Contains('-windows'))">1F9C3A44-059B-4FBC-9D92-476E59FB937A</ApplicationId>
+		<ApplicationIdGuid>1F9C3A44-059B-4FBC-9D92-476E59FB937A</ApplicationIdGuid>
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
-		<!-- Required for C# Hot Reload -->
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -1,56 +1,59 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
-		<OutputType>Exe</OutputType>
-		<RootNamespace>CommunityToolkit.Maui.Markup.Sample</RootNamespace>
-		<UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject>
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-		<!-- Display name -->
-		<ApplicationTitle>Sample</ApplicationTitle>
+  <PropertyGroup>
+    <TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CommunityToolkit.Maui.Markup.Sample</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
 
-		<!-- App Identifier -->
-		<ApplicationId>com.CommunityToolkit.MarkupSample</ApplicationId>
-		<ApplicationIdGuid>1F9C3A44-059B-4FBC-9D92-476E59FB937A</ApplicationIdGuid>
+    <!-- Display name -->
+    <ApplicationTitle>CommunityToolkit.Maui.Markup.Sample</ApplicationTitle>
 
-		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
+    <!-- App Identifier -->
+    <ApplicationId>com.CommunityToolkit.MarkupSample</ApplicationId>
+    <ApplicationIdGuid>BBD0FFD6-2530-47FC-8A89-C12FF625C5BF</ApplicationIdGuid>
 
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-	</PropertyGroup>
+    <!-- Versions -->
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <ApplicationVersion>1</ApplicationVersion>
 
-	<ItemGroup>
-		<!-- App Icon -->
-		<MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+  </PropertyGroup>
 
-		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
+  <ItemGroup>
+    <!-- App Icon -->
+    <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />
 
-		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
+    <!-- Splash Screen -->
+    <MauiSplashScreen Include="Resources\appiconfg.svg" Color="#512BD4" BaseSize="128,128" />
 
-		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
+    <!-- Images -->
+    <MauiImage Include="Resources\Images\*" />
+    <MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
-		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
+    <!-- Custom Fonts -->
+    <MauiFont Include="Resources\Fonts\*" />
 
-	<ItemGroup>
-		<PackageReference Include="Polly" Version="7.2.3" />
-		<PackageReference Include="Refit" Version="6.3.2" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
-	</ItemGroup>
+    <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+    <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="1.0.0-rc2" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Refit" Version="6.3.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -16,7 +16,7 @@ public class MauiProgram
 	{
 		var builder = MauiApp.CreateBuilder()
 								.UseMauiApp<App>()
-								.UseMauiCommunityToolkit()
+								// .UseMauiCommunityToolkit() // Temporarily remove CommunityToolkit.Maui-rc1 until CommunityToolkit.Maui-rc2 is available
 								.UseMauiCommunityToolkitMarkup();
 
 		// Fonts

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -12,11 +12,11 @@ namespace CommunityToolkit.Maui.Markup.Sample;
 
 public class MauiProgram
 {
-	public static MauiApp Create()
+	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder()
 								.UseMauiApp<App>()
-								// .UseMauiCommunityToolkit() // Temporarily remove CommunityToolkit.Maui-rc1 until CommunityToolkit.Maui-rc2 is available
+								.UseMauiCommunityToolkit()
 								.UseMauiCommunityToolkitMarkup();
 
 		// Fonts

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -1,5 +1,5 @@
 ﻿using System.Globalization;
-using CommunityToolkit.Maui;
+using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Markup.Sample.Constants;
 using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.Services;

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using CommunityToolkit.Maui;
 using CommunityToolkit.Maui.Markup.Sample.Constants;
 using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.Services;
@@ -33,7 +34,6 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 					.Placeholder($"Provide a value between {SettingsService.MinimumStoriesToFetch} and {SettingsService.MaximumStoriesToFetch}", Colors.Grey)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0.5, 45, 0.8, 40)
-					/* Temporarily remove CommunityToolkit.Maui-rc1 until CommunityToolkit.Maui-rc2 is available
 					.Behaviors(new NumericValidationBehavior
 					{
 						Flags = ValidationFlags.ValidateOnValueChanged,
@@ -42,7 +42,6 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 						InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
 						ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
 					})
-					*/
 					.Bind(Entry.TextProperty, nameof(SettingsViewModel.NumberOfTopStoriesToFetch))
 					.TextCenter(),
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -1,5 +1,4 @@
 ﻿using System.Globalization;
-using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Markup.Sample.Constants;
 using CommunityToolkit.Maui.Markup.Sample.Pages.Base;
 using CommunityToolkit.Maui.Markup.Sample.Services;
@@ -34,6 +33,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 					.Placeholder($"Provide a value between {SettingsService.MinimumStoriesToFetch} and {SettingsService.MaximumStoriesToFetch}", Colors.Grey)
 					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0.5, 45, 0.8, 40)
+					/* Temporarily remove CommunityToolkit.Maui-rc1 until CommunityToolkit.Maui-rc2 is available
 					.Behaviors(new NumericValidationBehavior
 					{
 						Flags = ValidationFlags.ValidateOnValueChanged,
@@ -42,6 +42,7 @@ class SettingsPage : BaseContentPage<SettingsViewModel>
 						InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
 						ValidStyle = new Style<Entry>(Entry.TextColorProperty, ColorConstants.PrimaryTextColor),
 					})
+					*/
 					.Bind(Entry.TextProperty, nameof(SettingsViewModel.NumberOfTopStoriesToFetch))
 					.TextCenter(),
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Android/AndroidManifest.xml
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Android/MainApplication.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Android/MainApplication.cs
@@ -14,5 +14,5 @@ public class MainApplication : MauiApplication
 	{
 	}
 
-	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
+	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/MacCatalyst/AppDelegate.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/MacCatalyst/AppDelegate.cs
@@ -7,5 +7,5 @@ namespace CommunityToolkit.Maui.Markup.Sample;
 [Register(nameof(AppDelegate))]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
+	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
@@ -7,7 +7,7 @@ namespace CommunityToolkit.Maui.Markup.Sample.Windows;
 
 public partial class App : MauiWinUIApplication
 {
-	public App() => this.InitializeComponent();
+	public App() => InitializeComponent();
 
 	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
@@ -3,24 +3,11 @@ using Microsoft.Maui.Hosting;
 using Microsoft.UI.Xaml;
 using Windows.ApplicationModel;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace CommunityToolkit.Maui.Markup.Sample.Windows;
 
-/// <summary>
-/// Provides application-specific behavior to supplement the default Application class.
-/// </summary>
 public partial class App : MauiWinUIApplication
 {
-	/// <summary>
-	/// Initializes the singleton application object.  This is the first line of authored code
-	/// executed, and as such is the logical equivalent of main() or WinMain().
-	/// </summary>
-	public App()
-	{
-		this.InitializeComponent();
-	}
+	public App() => this.InitializeComponent();
 
 	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/App.xaml.cs
@@ -1,13 +1,11 @@
-﻿using Microsoft.Maui;
-using Microsoft.Maui.Hosting;
-using Microsoft.UI.Xaml;
-using Windows.ApplicationModel;
+﻿using Microsoft.UI.Xaml;
 
 namespace CommunityToolkit.Maui.Markup.Sample.Windows;
 
 public partial class App : MauiWinUIApplication
 {
-	public App() => InitializeComponent();
+    public App() => this.InitializeComponent();
 
-	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }
+

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/Package.appxmanifest
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/Package.appxmanifest
@@ -1,34 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Publisher="CN=Microsoft" />
+    <Identity Publisher="CN=CommunityToolkit" />
 
-  <Properties>
-    <PublisherDisplayName>CommunityToolkit</PublisherDisplayName>
-  </Properties>
+    <Properties>
+        <PublisherDisplayName>CommunityToolkit</PublisherDisplayName>
+    </Properties>
 
-  <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-  </Dependencies>
+    <Dependencies>
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+        <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    </Dependencies>
 
-  <Resources>
-    <Resource Language="x-generate" />
-  </Resources>
+    <Resources>
+        <Resource Language="x-generate" />
+    </Resources>
 
-  <Applications>
-    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements />
-    </Application>
-  </Applications>
+    <Applications>
+        <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+            <uap:VisualElements />
+        </Application>
+    </Applications>
 
-  <Capabilities>
-    <rescap:Capability Name="runFullTrust" />
-  </Capabilities>
- 
+    <Capabilities>
+        <rescap:Capability Name="runFullTrust" />
+    </Capabilities>
+
 </Package>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/Package.appxmanifest
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/Package.appxmanifest
@@ -5,29 +5,29 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-    <Identity Publisher="CN=Microsoft" />
+  <Identity Publisher="CN=Microsoft" />
 
-    <Properties>
-        <PublisherDisplayName>CommunityToolkit</PublisherDisplayName>
-    </Properties>
+  <Properties>
+    <PublisherDisplayName>CommunityToolkit</PublisherDisplayName>
+  </Properties>
 
-    <Dependencies>
-        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-        <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    </Dependencies>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
 
-    <Resources>
-        <Resource Language="x-generate" />
-    </Resources>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
 
-    <Applications>
-        <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-            <uap:VisualElements />
-        </Application>
-    </Applications>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+      <uap:VisualElements />
+    </Application>
+  </Applications>
 
-    <Capabilities>
-        <rescap:Capability Name="runFullTrust" />
-    </Capabilities>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
 
 </Package>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/Package.appxmanifest
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Windows/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-    <Identity Publisher="CN=CommunityToolkit" />
+    <Identity Publisher="CN=Microsoft" />
 
     <Properties>
         <PublisherDisplayName>CommunityToolkit</PublisherDisplayName>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/iOS/AppDelegate.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/iOS/AppDelegate.cs
@@ -7,5 +7,5 @@ namespace CommunityToolkit.Maui.Markup.Sample;
 [Register(nameof(AppDelegate))]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-	protected override MauiApp CreateMauiApp() => MauiProgram.Create();
+	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR updates the Windows Sample app to match the [updated template](https://github.com/dotnet/maui/blob/main/src/Templates/src/templates/maui-mobile/MauiApp.1.csproj):
- Update `SupportedOSPlatformVersion`
- Update `TargetPlatformMinVersion`
- Update `Package.appxmanifest`

### Additional Information

This PR also updates `azurepipelines.yml` to leverage `VSBuild@1` for the `Build Markup Community Toolkit Sample` step. This ensures that the Windows Sample app is built during our CI Pipeline.