### PR TITLE
Fix TextAlignmentExtensions Class Names and XML Docs

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 
 namespace CommunityToolkit.Maui.Markup.UnitTests
 {
-
 	[TestFixture]
 	class TextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
 	{

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -3,58 +3,96 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using NUnit.Framework;
 
-namespace CommunityToolkit.Maui.Markup.UnitTests;
-
-[TestFixture]
-class TextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
+namespace CommunityToolkit.Maui.Markup.UnitTests
 {
-	[Test]
-	public void TextStart()
-		=> TestPropertiesSet(l => l.TextStart(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End, TextAlignment.Start));
 
-	[Test]
-	public void TextCenterHorizontal()
-		=> TestPropertiesSet(l => l.TextCenterHorizontal(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
-
-	[Test]
-	public void TextEnd()
-		=> TestPropertiesSet(l => l.TextEnd(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.End));
-
-	[Test]
-	public void TextTop()
-		=> TestPropertiesSet(l => l.TextTop(), (TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.End, TextAlignment.Start));
-
-	[Test]
-	public void TextCenterVertical()
-		=> TestPropertiesSet(l => l.TextCenterVertical(), (TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
-
-	[Test]
-	public void TextBottom()
-		=> TestPropertiesSet(l => l.TextBottom(), (TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.End));
-
-	[Test]
-	public void TextCenter()
-		=> TestPropertiesSet(
-				l => l.TextCenter(),
-				(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center),
-				(TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
-
-	[Test]
-	public void SupportDerivedFromBindable()
+	[TestFixture]
+	class TextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
 	{
-		Assert.IsInstanceOf<DerivedFromSearchBar>(
-			new DerivedFromSearchBar()
-			.TextStart()
-			.TextCenterHorizontal()
-			.TextEnd()
-			.TextTop()
-			.TextCenterVertical()
-			.TextBottom()
-			.TextCenter()
-			.FontSize(8.0)
-			.Bold()
-			.Italic());
-	}
+		[Test]
+		public void TextStart()
+			=> TestPropertiesSet(l => l.TextStart(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End, TextAlignment.Start));
 
-	class DerivedFromSearchBar : SearchBar { }
+		[Test]
+		public void TextCenterHorizontal()
+			=> TestPropertiesSet(l => l.TextCenterHorizontal(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
+
+		[Test]
+		public void TextEnd()
+			=> TestPropertiesSet(l => l.TextEnd(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.End));
+
+		[Test]
+		public void TextTop()
+			=> TestPropertiesSet(l => l.TextTop(), (TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.End, TextAlignment.Start));
+
+		[Test]
+		public void TextCenterVertical()
+			=> TestPropertiesSet(l => l.TextCenterVertical(), (TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
+
+		[Test]
+		public void TextBottom()
+			=> TestPropertiesSet(l => l.TextBottom(), (TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.End));
+
+		[Test]
+		public void TextCenter()
+			=> TestPropertiesSet(
+					l => l.TextCenter(),
+					(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center),
+					(TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
+
+		[Test]
+		public void SupportDerivedFromBindable()
+		{
+			Assert.IsInstanceOf<DerivedFromSearchBar>(
+				new DerivedFromSearchBar()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter()
+				.FontSize(8.0)
+				.Bold()
+				.Italic());
+		}
+
+		class DerivedFromSearchBar : SearchBar { }
+	}
+}
+
+namespace CommunityToolkit.Maui.Markup.UnitTests
+{
+	using CommunityToolkit.Maui.Markup.LeftToRight;
+
+	[TestFixture]
+	class LeftToRightTextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
+	{
+
+		[Test]
+		public void TextLeft()
+			=> TestPropertiesSet(l => l.TextLeft(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start));
+
+		[Test]
+		public void TextRight()
+			=> TestPropertiesSet(l => l.TextRight(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End));
+	}
+}
+
+namespace CommunityToolkit.Maui.Markup.UnitTests
+{
+	using CommunityToolkit.Maui.Markup.RightToLeft;
+
+	[TestFixture]
+	class RightToLeftTextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
+	{
+
+		[Test]
+		public void TextLeft()
+			=> TestPropertiesSet(l => l.TextLeft(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End));
+
+		[Test]
+		public void TextRight()
+			=> TestPropertiesSet(l => l.TextRight(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start));
+	}
 }

--- a/src/CommunityToolkit.Maui.Markup/TextAlignmentExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/TextAlignmentExtensions.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Markup
 	public static class TextAlignmentExtensions
 	{
 		/// <summary>
-		/// HorizontalTextAlignment = TextAlignment.Start
+		/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.Start"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -21,7 +21,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// HorizontalTextAlignment = TextAlignment.Center
+		/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.Center"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -33,7 +33,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// HorizontalTextAlignment = TextAlignment.End
+		/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.End"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -45,7 +45,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalTextAlignment = TextAlignment.Start
+		/// <see cref="ITextAlignment.VerticalTextAlignment"/> = <see cref="TextAlignment.Start"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -57,7 +57,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalTextAlignment = TextAlignment.Center
+		/// <see cref="ITextAlignment.VerticalTextAlignment"/> = <see cref="TextAlignment.Center"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -69,7 +69,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalTextAlignment = TextAlignment.End
+		/// <see cref="ITextAlignment.VerticalTextAlignment"/> = <see cref="TextAlignment.End"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -81,7 +81,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalTextAlignment = HorizontalTextAlignment = TextAlignment.Center
+		/// <see cref="ITextAlignment.VerticalTextAlignment"/> = <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.Center"/>
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
@@ -93,6 +93,10 @@ namespace CommunityToolkit.Maui.Markup
 
 	// The extensions in these sub-namespaces are designed to be used together with the extensions in the parent namespace.
 	// Keep them in a single file for better maintainability
+
+	/// <summary>
+	/// Extension Methods for Left-to-Right Text
+	/// </summary>
 	namespace LeftToRight
 	{
 		/// <summary>
@@ -101,7 +105,7 @@ namespace CommunityToolkit.Maui.Markup
 		public static class TextAlignmentExtensions
 		{
 			/// <summary>
-			/// HorizontalTextAlignment = TextAlignment.Start
+			/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.Start"/>
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
@@ -113,7 +117,7 @@ namespace CommunityToolkit.Maui.Markup
 			}
 
 			/// <summary>
-			/// HorizontalTextAlignment = TextAlignment.End
+			/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.End"/>
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
@@ -126,15 +130,21 @@ namespace CommunityToolkit.Maui.Markup
 		}
 	}
 
+	// The extensions in these sub-namespaces are designed to be used together with the extensions in the parent namespace.
+	// Keep them in a single file for better maintainability
+
+	/// <summary>
+	/// Extension Methods for Right-to-Left Text
+	/// </summary>
 	namespace RightToLeft
 	{
 		/// <summary>
-		/// Extension methods for Label
+		/// Extension methods for ITextAlignment
 		/// </summary>
-		public static class LabelExtensions
+		public static class TextAlignmentExtensions
 		{
 			/// <summary>
-			/// HorizontalTextAlignment = TextAlignment.End
+			/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.End"/>
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
@@ -146,7 +156,7 @@ namespace CommunityToolkit.Maui.Markup
 			}
 
 			/// <summary>
-			/// HorizontalTextAlignment = TextAlignment.Start
+			/// <see cref="ITextAlignment.HorizontalTextAlignment"/> = <see cref="TextAlignment.Start"/>
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>

--- a/src/CommunityToolkit.Maui.Markup/TextAlignmentExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/TextAlignmentExtensions.cs
@@ -4,7 +4,7 @@ using Microsoft.Maui.Controls;
 namespace CommunityToolkit.Maui.Markup
 {
 	/// <summary>
-	/// Extension Methods for ITextAlignment
+	/// Extension Methods for <see cref="ITextAlignment"/>
 	/// </summary>
 	public static class TextAlignmentExtensions
 	{
@@ -13,7 +13,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns>Label with added TextAlignment.Start</returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.Start"/></returns>
 		public static TBindable TextStart<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 		{
 			bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start);
@@ -25,7 +25,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns>Label with added TextAlignment.Center</returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.Center"/></returns>
 		public static TBindable TextCenterHorizontal<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 		{
 			bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Center);
@@ -37,7 +37,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns>Label with added TextAlignment.End</returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.End"/></returns>
 		public static TBindable TextEnd<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 		{
 			bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End);
@@ -49,7 +49,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns>Label with added TextAlignment.Start</returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.Start"/></returns>
 		public static TBindable TextTop<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 		{
 			bindable.SetValue(TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start);
@@ -61,7 +61,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns>Label with added TextAlignment.Center</returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.Center"/></returns>
 		public static TBindable TextCenterVertical<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 		{
 			bindable.SetValue(TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Center);
@@ -73,7 +73,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns>Label with added TextAlignment.End</returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.End"/></returns>
 		public static TBindable TextBottom<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 		{
 			bindable.SetValue(TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.End);
@@ -85,7 +85,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// </summary>
 		/// <typeparam name="TBindable"></typeparam>
 		/// <param name="bindable"></param>
-		/// <returns></returns>
+		/// <returns><typeparam name="TBindable"/> with added <see cref="TextAlignment.Center"/></returns>
 		public static TBindable TextCenter<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 			=> bindable.TextCenterHorizontal().TextCenterVertical();
 	}
@@ -100,7 +100,7 @@ namespace CommunityToolkit.Maui.Markup
 	namespace LeftToRight
 	{
 		/// <summary>
-		/// Extension Methods for ITextAlignment
+		/// Extension Methods for <see cref="ITextAlignment"/>
 		/// </summary>
 		public static class TextAlignmentExtensions
 		{
@@ -109,7 +109,7 @@ namespace CommunityToolkit.Maui.Markup
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
-			/// <returns>Label with TextAlignment.Start</returns>
+			/// <returns><typeparam name="TBindable"/> with <see cref="TextAlignment.Start"/></returns>
 			public static TBindable TextLeft<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 			{
 				bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start);
@@ -121,7 +121,7 @@ namespace CommunityToolkit.Maui.Markup
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
-			/// <returns>Label with TextAligment.End</returns>
+			/// <returns><typeparam name="TBindable"/> with <see cref="TextAlignment.End"/></returns>
 			public static TBindable TextRight<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 			{
 				bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End);
@@ -139,7 +139,7 @@ namespace CommunityToolkit.Maui.Markup
 	namespace RightToLeft
 	{
 		/// <summary>
-		/// Extension methods for ITextAlignment
+		/// Extension methods for <see cref="ITextAlignment"/>
 		/// </summary>
 		public static class TextAlignmentExtensions
 		{
@@ -148,7 +148,7 @@ namespace CommunityToolkit.Maui.Markup
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
-			/// <returns>Label with TextAlignment.End</returns>
+			/// <returns><typeparam name="TBindable"/> with <see cref="TextAlignment.End"/></returns>
 			public static TBindable TextLeft<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 			{
 				bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End);
@@ -160,7 +160,7 @@ namespace CommunityToolkit.Maui.Markup
 			/// </summary>
 			/// <typeparam name="TBindable"></typeparam>
 			/// <param name="bindable"></param>
-			/// <returns>Label with TextAlignment.Start</returns>
+			/// <returns><typeparam name="TBindable"/> with <see cref="TextAlignment.Start"/></returns>
 			public static TBindable TextRight<TBindable>(this TBindable bindable) where TBindable : BindableObject, ITextAlignment
 			{
 				bindable.SetValue(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start);

--- a/src/CommunityToolkit.Maui.Markup/TextAlignmentExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/TextAlignmentExtensions.cs
@@ -96,9 +96,9 @@ namespace CommunityToolkit.Maui.Markup
 	namespace LeftToRight
 	{
 		/// <summary>
-		/// Extension methods for Labels
+		/// Extension Methods for ITextAlignment
 		/// </summary>
-		public static class LabelExtensions
+		public static class TextAlignmentExtensions
 		{
 			/// <summary>
 			/// HorizontalTextAlignment = TextAlignment.Start


### PR DESCRIPTION
 ### Description of Change ###

This PR updates the following in `TextAlignmentExtensions.cs`:
- Rename `LeftToRight.LabelExtensions` to `LeftToRight.TextAlignmentExtensions`
  - This aligns with the existing class `CommunityToolkit.Maui.Markup.TextAlignmentExtensions`
  - The extension methods in this class all implement `T where T : ITextAlignment`
- Rename `RightToLeft.LabelExtensions` to `RightToLeft.TextAlignmentExtensions`
  - This aligns with the existing class `CommunityToolkit.Maui.Markup.TextAlignmentExtensions`
  - The extension methods in this class all implement `T where T : ITextAlignment`
- Update XML Docs to use `<see ref.../>` to reference types
 
### Additional Information
This PR also adds missing unit tests for `LeftToRight.TextAlignmentExtensions` and `LeftToRight.LabelExtensions`
