### PR TITLE
Fix ViewExtensions XML Docs, Add Missing Unit Tests

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ViewExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ViewExtensionsTests.cs
@@ -3,92 +3,128 @@ using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using NUnit.Framework;
 
-namespace CommunityToolkit.Maui.Markup.UnitTests;
-
-[TestFixture]
-class ViewExtensionsTests : BaseMarkupTestFixture<BoxView>
+namespace CommunityToolkit.Maui.Markup.UnitTests
 {
-	[Test]
-	public void Start()
-		=> TestPropertiesSet(v => v.Start(), (View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Start));
 
-	[Test]
-	public void CenterHorizontal()
-		=> TestPropertiesSet(v => v.CenterHorizontal(), (View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Center));
-
-	[Test]
-	public void FillHorizontal()
-		=> TestPropertiesSet(v => v.FillHorizontal(), (View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill));
-
-	[Test]
-	public void End()
-		=> TestPropertiesSet(v => v.End(), (View.HorizontalOptionsProperty, LayoutOptions.Start, LayoutOptions.End));
-
-	[Test]
-	public void Top()
-		=> TestPropertiesSet(v => v.Top(), (View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Start));
-
-	[Test]
-	public void Bottom()
-		=> TestPropertiesSet(v => v.Bottom(), (View.VerticalOptionsProperty, LayoutOptions.Start, LayoutOptions.End));
-
-	[Test]
-	public void CenterVertical()
-		=> TestPropertiesSet(v => v.CenterVertical(), (View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Center));
-
-	[Test]
-	public void FillVertical()
-		=> TestPropertiesSet(v => v.FillVertical(), (View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill));
-
-	[Test]
-	public void Center()
-		=> TestPropertiesSet(
-				v => v.Center(),
-				(View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Center),
-				(View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Center));
-
-	[Test]
-	public void Fill()
-		=> TestPropertiesSet(
-				v => v.Fill(),
-				(View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill),
-				(View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill));
-
-	[Test]
-	public void MarginThickness()
-		=> TestPropertiesSet(v => v.Margin(new Thickness(1)), (View.MarginProperty, new Thickness(0), new Thickness(1)));
-
-	[Test]
-	public void MarginUniform()
-		=> TestPropertiesSet(v => v.Margin(1), (View.MarginProperty, new Thickness(0), new Thickness(1)));
-
-	[Test]
-	public void MarginHorizontalVertical()
-		=> TestPropertiesSet(v => v.Margin(1, 2), (View.MarginProperty, new Thickness(0), new Thickness(1, 2)));
-
-	[Test]
-	public void Margins()
-		=> TestPropertiesSet(v => v.Margins(left: 1, top: 2, right: 3, bottom: 4), (View.MarginProperty, new Thickness(0), new Thickness(1, 2, 3, 4)));
-
-	[Test]
-	public void SupportDerivedFromView()
+	[TestFixture]
+	class ViewExtensionsTests : BaseMarkupTestFixture<BoxView>
 	{
-		Assert.IsInstanceOf<DerivedFromView>(
-			new DerivedFromView()
-			.Start()
-			.CenterHorizontal()
-			.FillHorizontal()
-			.End()
-			.Top()
-			.Bottom()
-			.CenterVertical()
-			.FillVertical()
-			.Center()
-			.Fill()
-			.Margin(new Thickness(1))
-			.Margin(1, 2)
-			.Margins(left: 1, top: 2, right: 3, bottom: 4));
-	}
+		[Test]
+		public void Start()
+			=> TestPropertiesSet(v => v.Start(), (View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Start));
 
-	class DerivedFromView : BoxView { }
+		[Test]
+		public void CenterHorizontal()
+			=> TestPropertiesSet(v => v.CenterHorizontal(), (View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Center));
+
+		[Test]
+		public void FillHorizontal()
+			=> TestPropertiesSet(v => v.FillHorizontal(), (View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill));
+
+		[Test]
+		public void End()
+			=> TestPropertiesSet(v => v.End(), (View.HorizontalOptionsProperty, LayoutOptions.Start, LayoutOptions.End));
+
+		[Test]
+		public void Top()
+			=> TestPropertiesSet(v => v.Top(), (View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Start));
+
+		[Test]
+		public void Bottom()
+			=> TestPropertiesSet(v => v.Bottom(), (View.VerticalOptionsProperty, LayoutOptions.Start, LayoutOptions.End));
+
+		[Test]
+		public void CenterVertical()
+			=> TestPropertiesSet(v => v.CenterVertical(), (View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Center));
+
+		[Test]
+		public void FillVertical()
+			=> TestPropertiesSet(v => v.FillVertical(), (View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill));
+
+		[Test]
+		public void Center()
+			=> TestPropertiesSet(
+					v => v.Center(),
+					(View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Center),
+					(View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Center));
+
+		[Test]
+		public void Fill()
+			=> TestPropertiesSet(
+					v => v.Fill(),
+					(View.HorizontalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill),
+					(View.VerticalOptionsProperty, LayoutOptions.End, LayoutOptions.Fill));
+
+		[Test]
+		public void MarginThickness()
+			=> TestPropertiesSet(v => v.Margin(new Thickness(1)), (View.MarginProperty, new Thickness(0), new Thickness(1)));
+
+		[Test]
+		public void MarginUniform()
+			=> TestPropertiesSet(v => v.Margin(1), (View.MarginProperty, new Thickness(0), new Thickness(1)));
+
+		[Test]
+		public void MarginHorizontalVertical()
+			=> TestPropertiesSet(v => v.Margin(1, 2), (View.MarginProperty, new Thickness(0), new Thickness(1, 2)));
+
+		[Test]
+		public void Margins()
+			=> TestPropertiesSet(v => v.Margins(left: 1, top: 2, right: 3, bottom: 4), (View.MarginProperty, new Thickness(0), new Thickness(1, 2, 3, 4)));
+
+		[Test]
+		public void SupportDerivedFromView()
+		{
+			Assert.IsInstanceOf<DerivedFromView>(
+				new DerivedFromView()
+				.Start()
+				.CenterHorizontal()
+				.FillHorizontal()
+				.End()
+				.Top()
+				.Bottom()
+				.CenterVertical()
+				.FillVertical()
+				.Center()
+				.Fill()
+				.Margin(new Thickness(1))
+				.Margin(1, 2)
+				.Margins(left: 1, top: 2, right: 3, bottom: 4));
+		}
+
+		class DerivedFromView : BoxView { }
+	}
+}
+
+namespace CommunityToolkit.Maui.Markup.UnitTests
+{
+	using CommunityToolkit.Maui.Markup.LeftToRight;
+
+	[TestFixture]
+	class LeftToRightViewExtensionsTests : BaseMarkupTestFixture<BoxView>
+	{
+		[Test]
+		public void Left()
+			=> TestPropertiesSet(v => v.Left(), (View.HorizontalOptionsProperty, LayoutOptions.Start));
+
+		[Test]
+		public void Right()
+			=> TestPropertiesSet(v => v.Right(), (View.HorizontalOptionsProperty, LayoutOptions.End));
+	}
+}
+
+namespace CommunityToolkit.Maui.Markup.UnitTests
+{
+	using CommunityToolkit.Maui.Markup.RightToLeft;
+
+	[TestFixture]
+	class RightToLeftViewExtensionsTests : BaseMarkupTestFixture<BoxView>
+	{
+		[Test]
+		public void Left()
+			=> TestPropertiesSet(v => v.Left(), (View.HorizontalOptionsProperty, LayoutOptions.End));
+
+		[Test]
+		public void Right()
+			=> TestPropertiesSet(v => v.Right(), (View.HorizontalOptionsProperty, LayoutOptions.Start));
+	}
 }

--- a/src/CommunityToolkit.Maui.Markup/ViewExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ViewExtensions.cs
@@ -9,11 +9,11 @@ namespace CommunityToolkit.Maui.Markup
 	public static class ViewExtensions
 	{
 		/// <summary>
-		/// HorizontalOptions = LayoutOptions.Start
+		/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Start"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Start</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Start"/></returns>
 		public static TView Start<TView>(this TView view) where TView : View
 		{
 			view.HorizontalOptions = LayoutOptions.Start;
@@ -21,11 +21,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// HorizontalOptions = LayoutOptions.Center
+		/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Center"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Center</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Center"/></returns>
 		public static TView CenterHorizontal<TView>(this TView view) where TView : View
 		{
 			view.HorizontalOptions = LayoutOptions.Center;
@@ -33,11 +33,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// HorizontalOptions = LayoutOptions.Fill
+		/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Fill"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Fill</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Fill"/></returns>
 		public static TView FillHorizontal<TView>(this TView view) where TView : View
 		{
 			view.HorizontalOptions = LayoutOptions.Fill;
@@ -45,11 +45,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// HorizontalOptions = LayoutOptions.End
+		/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.End"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.End</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.End"/></returns>
 		public static TView End<TView>(this TView view) where TView : View
 		{
 			view.HorizontalOptions = LayoutOptions.End;
@@ -57,11 +57,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalOptions = LayoutOptions.Start
+		/// <see cref="View.VerticalOptions"/> = <see cref="LayoutOptions.Start"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Start</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Start"/></returns>
 		public static TView Top<TView>(this TView view) where TView : View
 		{
 			view.VerticalOptions = LayoutOptions.Start;
@@ -69,11 +69,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalOptions = LayoutOptions.End
+		/// <see cref="View.VerticalOptions"/> = <see cref="LayoutOptions.End"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.End</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.End"/></returns>
 		public static TView Bottom<TView>(this TView view) where TView : View
 		{
 			view.VerticalOptions = LayoutOptions.End;
@@ -81,11 +81,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalOptions = LayoutOptions.Center
+		/// <see cref="View.VerticalOptions"/> = <see cref="LayoutOptions.Center"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Center</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Center"/></returns>
 		public static TView CenterVertical<TView>(this TView view) where TView : View
 		{
 			view.VerticalOptions = LayoutOptions.Center;
@@ -93,11 +93,11 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalOptions = LayoutOptions.Fill
+		/// <see cref="View.VerticalOptions"/> = <see cref="LayoutOptions.Fill"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Fill</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Fill"/></returns>
 		public static TView FillVertical<TView>(this TView view) where TView : View
 		{
 			view.VerticalOptions = LayoutOptions.Fill;
@@ -105,30 +105,30 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// VerticalOptions = HorizontalOptions = LayoutOptions.Center
+		/// <see cref="View.VerticalOptions"/> = <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Center"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.Center</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Center"/></returns>
 		public static TView Center<TView>(this TView view) where TView : View
 			=> view.CenterHorizontal().CenterVertical();
 
 		/// <summary>
-		/// VerticalOptions = HorizontalOptions = LayoutOptions.Fill
+		/// <see cref="View.VerticalOptions"/> = <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Fill"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
-		/// <returns>View with LayoutOptions.FillAndExpand</returns>
+		/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Fill"/></returns>
 		public static TView Fill<TView>(this TView view) where TView : View
 			=> view.FillHorizontal().FillVertical();
 
 		/// <summary>
-		/// Set Margin
+		/// Set <see cref="View.Margin"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
 		/// <param name="margin"></param>
-		/// <returns>View with added margin</returns>
+		/// <returns><typeparam name="TView"/> with added <see cref="View.Margin"/></returns>
 		public static TView Margin<TView>(this TView view, Thickness margin) where TView : View
 		{
 			view.Margin = margin;
@@ -136,13 +136,13 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// Set Margin
+		/// Set <see cref="View.Margin"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
 		/// <param name="horizontal"></param>
 		/// <param name="vertical"></param>
-		/// <returns>View with added margin</returns>
+		/// <returns><typeparam name="TView"/> with added <see cref="View.Margin"/></returns>
 		public static TView Margin<TView>(this TView view, double horizontal, double vertical) where TView : View
 		{
 			view.Margin = new Thickness(horizontal, vertical);
@@ -150,7 +150,7 @@ namespace CommunityToolkit.Maui.Markup
 		}
 
 		/// <summary>
-		/// Set Margin
+		/// Set <see cref="View.Margin"/>
 		/// </summary>
 		/// <typeparam name="TView"></typeparam>
 		/// <param name="view"></param>
@@ -158,7 +158,7 @@ namespace CommunityToolkit.Maui.Markup
 		/// <param name="top"></param>
 		/// <param name="right"></param>
 		/// <param name="bottom"></param>
-		/// <returns>View with added margin</returns>
+		/// <returns><typeparam name="TView"/> with added <see cref="View.Margin"/></returns>
 		public static TView Margins<TView>(this TView view, double left = 0, double top = 0, double right = 0, double bottom = 0) where TView : View
 		{
 			view.Margin = new Thickness(left, top, right, bottom);
@@ -176,11 +176,11 @@ namespace CommunityToolkit.Maui.Markup
 		public static class ViewExtensions
 		{
 			/// <summary>
-			/// HorizontalOptions = LayoutOptions.Start
+			/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Start"/>
 			/// </summary>
 			/// <typeparam name="TView"></typeparam>
 			/// <param name="view"></param>
-			/// <returns>View with LayoutOptions.Start</returns>
+			/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Start"/></returns>
 			public static TView Left<TView>(this TView view) where TView : View
 			{
 				view.HorizontalOptions = LayoutOptions.Start;
@@ -188,11 +188,11 @@ namespace CommunityToolkit.Maui.Markup
 			}
 
 			/// <summary>
-			/// HorizontalOptions = LayoutOptions.End
+			/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.End"/>
 			/// </summary>
 			/// <typeparam name="TView"></typeparam>
 			/// <param name="view"></param>
-			/// <returns>View with LayoutOptions.End</returns>
+			/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.End"/></returns>
 			public static TView Right<TView>(this TView view) where TView : View
 			{
 				view.HorizontalOptions = LayoutOptions.End;
@@ -209,11 +209,11 @@ namespace CommunityToolkit.Maui.Markup
 		public static class ViewExtensions
 		{
 			/// <summary>
-			/// HorizontalOptions = LayoutOptions.End
+			/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.End"/>
 			/// </summary>
 			/// <typeparam name="TView"></typeparam>
 			/// <param name="view"></param>
-			/// <returns>View with LayoutOptions.End</returns>
+			/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.End"/></returns>
 			public static TView Left<TView>(this TView view) where TView : View
 			{
 				view.HorizontalOptions = LayoutOptions.End;
@@ -221,11 +221,11 @@ namespace CommunityToolkit.Maui.Markup
 			}
 
 			/// <summary>
-			/// HorizontalOptions = LayoutOptions.Start
+			/// <see cref="View.HorizontalOptions"/> = <see cref="LayoutOptions.Start"/>
 			/// </summary>
 			/// <typeparam name="TView"></typeparam>
 			/// <param name="view"></param>
-			/// <returns>View with LayoutOptions.Start</returns>
+			/// <returns><typeparam name="TView"/> with <see cref="LayoutOptions.Start"/></returns>
 			public static TView Right<TView>(this TView view) where TView : View
 			{
 				view.HorizontalOptions = LayoutOptions.Start;


### PR DESCRIPTION
 ### Description of Change ###

This PR updates the XML Docs to use `<see ref.../>` to reference types.
 
This PR also adds missing unit tests for `LeftToRight.TextAlignmentExtensions` and `LeftToRight.LabelExtensions`.