### PR TITLE
`.BindCommand()`: Search Base Types of `Microsoft.Maui.*` Classes for `CommandProperty` and `CommandParameterProperty`

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.UnitTests/DefaultBindablePropertiesTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/DefaultBindablePropertiesTests.cs
@@ -17,199 +17,51 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 	class DefaultBindablePropertiesTests : BaseMarkupTestFixture
 	{
 		[Test]
-		public void AllBindableElementsInCoreHaveDefaultBindablePropertyOrAreExcluded()
-		{
-			const string na = "not applicable", tbd = "to be determined";
-			IReadOnlyDictionary<Type, string> excludedTypeReasons = new Dictionary<Type, string>
-			{ // Key: type, Value: reason why it does not have a default bindable property
-				{ typeof(Application), na },
-				{ typeof(AdaptiveTrigger), na },
-				{ typeof(BaseMenuItem), na },
-				{ typeof(BaseShellItem), na },
-				{ typeof(Behavior), na },
-				{ typeof(BindableObject), na },
-				{ typeof(CarouselView), na },
-				{ typeof(Cell), na },
-				{ typeof(ColumnDefinition), na },
-				{ typeof(CompareStateTrigger), na },
-				{ typeof(DataTrigger), na },
-				{ typeof(DeviceStateTrigger), na },
-				{ typeof(DragGestureRecognizer), na },
-				{ typeof(DropGestureRecognizer), na },
-				{ typeof(Element), na },
-				{ typeof(EventTrigger), na },
-				{ typeof(FontImageSource), na },
-				{ typeof(FormattedString), na },
-				{ typeof(GestureElement), na },
-				{ typeof(GestureRecognizer), na },
-				{ typeof(GradientStop), na },
-				{ typeof(GridItemsLayout), na },
-				{ typeof(GroupableItemsView), na },
-				{ typeof(HorizontalStackLayout), na },
-				{ typeof(ImageSource), na },
-				{ typeof(InputView), na },
-				{ typeof(ItemsLayout), na },
-				{ typeof(LinearItemsLayout), na },
-				{ typeof(LinearGradientBrush), na },
-				{ typeof(MenuBar), na },
-				{ typeof(MultiTrigger), na },
-				{ typeof(NavigableElement), na },
-				{ typeof(OpenGLView), na },
-				{ typeof(OrientationStateTrigger), na },
-				{ typeof(PanGestureRecognizer), na },
-				{ typeof(PinchGestureRecognizer), na },
-				{ typeof(RadialGradientBrush), na },
-				{ typeof(RoundRectangleGeometry), na },
-				{ typeof(RowDefinition), na },
-				{ typeof(SelectableItemsView), na },
-				{ typeof(StateTrigger), na },
-				{ typeof(StateTriggerBase), na },
-				{ typeof(StructuredItemsView), na },
-				{ typeof(SwipeItems), na },
-				{ typeof(TableRoot), na },
-				{ typeof(TableSection), na },
-				{ typeof(TableView), na },
-				{ typeof(Trigger), na },
-				{ typeof(TriggerBase), na },
-				{ typeof(VerticalStackLayout), na },
-				{ typeof(View), na },
-				{ typeof(ViewCell), na },
-				{ typeof(VisualElement), na },
-				{ typeof(WebViewSource), na },
-				{ typeof(Microsoft.Maui.Controls.Compatibility.AbsoluteLayout), na },
-				{ typeof(Microsoft.Maui.Controls.Compatibility.FlexLayout), na },
-				{ typeof(Microsoft.Maui.Controls.Compatibility.Grid), na },
-				{ typeof(Microsoft.Maui.Controls.Compatibility.RelativeLayout), na },
-				{ typeof(Microsoft.Maui.Controls.Compatibility.StackLayout), na },
-				{ typeof(AppLinkEntry), tbd },
-				{ typeof(FlyoutItem), tbd },
-				{ typeof(Shell), tbd },
-				{ typeof(ShellContent), tbd },
-				{ typeof(ShellGroupItem), tbd },
-				{ typeof(ShellItem), tbd },
-				{ typeof(ShellSection), tbd },
-				{ typeof(Tab), tbd },
-				{ typeof(TabBar), tbd },
-				{ typeof(ArcSegment), tbd },
-				{ typeof(BezierSegment), tbd },
-				{ typeof(CompositeTransform), tbd },
-				{ typeof(EllipseGeometry), tbd },
-				{ typeof(Geometry), tbd },
-				{ typeof(GeometryGroup), tbd },
-				{ typeof(LineGeometry), tbd },
-				{ typeof(LineSegment), tbd },
-				{ typeof(MatrixTransform), tbd },
-				{ typeof(Path), tbd },
-				{ typeof(PathFigure), tbd },
-				{ typeof(PathGeometry), tbd },
-				{ typeof(PathSegment), tbd },
-				{ typeof(PolyBezierSegment), tbd },
-				{ typeof(PolyLineSegment), tbd },
-				{ typeof(PolyQuadraticBezierSegment), tbd },
-				{ typeof(QuadraticBezierSegment), tbd },
-				{ typeof(RectangleGeometry), tbd },
-				{ typeof(RotateTransform), tbd },
-				{ typeof(ScaleTransform), tbd },
-				{ typeof(SkewTransform), tbd },
-				{ typeof(Shape), tbd },
-				{ typeof(Transform), tbd },
-				{ typeof(TransformGroup), tbd },
-				{ typeof(TranslateTransform), tbd },
-				{ typeof(Ellipse), tbd },
-				{ typeof(Line), tbd },
-				{ typeof(Polygon), tbd },
-				{ typeof(Polyline), tbd },
-				{ typeof(Rectangle), tbd },
-				{ typeof(ScrollView), tbd },
-				{ typeof(RoundRectangle), tbd },
-			};
-
-			var failMessage = new StringBuilder();
-			var bindableObjectTypes = typeof(BindableObject).Assembly.GetExportedTypes()
-				.Where(t => typeof(BindableObject).IsAssignableFrom(t) && !t.IsAbstract && !typeof(Layout).IsAssignableFrom(t) && !t.ContainsGenericParameters);
-
-			// The logical default property for a Layout is for its child view(s), which is not a bindable property.
-			// So we exclude Layouts from this test. Note that it is still perfectly OK to define a default
-			// bindable property for a Layout where that makes sense.
-			// We also do not support specifying default properties for unconstructed generic types.
-
-			foreach (var type in bindableObjectTypes)
-			{
-				if (excludedTypeReasons.TryGetValue(type, out var exclusionReason))
-				{
-					Console.WriteLine($"Info: no default BindableProperty defined for BindableObject type {type.FullName} because {exclusionReason}");
-					continue;
-				}
-
-				if (DefaultBindableProperties.GetFor(type) is null)
-				{
-					failMessage.AppendLine(type.FullName);
-					var propertyNames = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
-										.Where(f => f.FieldType == typeof(BindableProperty)).Select(f => f?.DeclaringType?.Name + "." + f?.Name).ToList();
-
-					if (propertyNames.Count > 0)
-					{
-						failMessage.AppendLine("\tCandidate properties:");
-						foreach (var propertyName in propertyNames)
-						{
-							failMessage.Append('\t').AppendLine(propertyName);
-						}
-					}
-				}
-			}
-
-			if (failMessage.Length > 0)
-			{
-				Assert.Fail(
-					$"Missing default BindableProperty / exclusion for BindableObject types:\n{failMessage}\n" +
-					$"Either register these types in {typeof(DefaultBindableProperties).FullName} or exclude them in this test");
-			}
-		}
-
-		[Test]
 		public void GetDefaultBindablePropertyForBuiltInType()
-			=> Assert.That(DefaultBindableProperties.GetFor(new Label()), Is.Not.Null);
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<Label>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindablePropertyForDerivedType()
-			=> Assert.That(DefaultBindableProperties.GetFor(new DerivedFromBoxView()), Is.Not.Null);
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<DerivedFromBoxView>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindablePropertyForUnsupportedType()
 			=> Assert.Throws<ArgumentException>(
-				() => DefaultBindableProperties.GetFor(new CustomView()),
+				() => DefaultBindableProperties.GetDefaultProperty<CustomView>(),
 				"No default bindable property is registered for BindableObject type XamarinFormsMarkupUnitTestsDefaultBindablePropertiesViews.CustomView" +
 				"\r\nEither specify a property when calling Bind() or register a default bindable property for this BindableObject type");
 
 		[Test]
 		public void RegisterDefaultBindableProperty()
 		{
-			var v = new CustomViewWithText();
-			Assert.Throws<ArgumentException>(() => DefaultBindableProperties.GetFor(v));
+			Assert.Throws<ArgumentException>(() => DefaultBindableProperties.GetDefaultProperty<CustomViewWithText>());
 
 			DefaultBindableProperties.Register(CustomViewWithText.TextProperty);
 		}
 
 		[Test]
 		public void GetDefaultBindableCommandPropertiesForBuiltInType()
-			=> Assert.That(DefaultBindableProperties.GetForCommand(new Button()), Is.Not.Null);
+			=> Assert.That(DefaultBindableProperties.GetCommandAndCommandParameterProperty<Button>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindableCommandPropertiesForDerivedType()
-			=> Assert.That(DefaultBindableProperties.GetFor(new DerivedFromButton()), Is.Not.Null);
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<DerivedFromButton>(), Is.Not.Null);
+
+		[Test]
+		public void GetDefaultBindableCommandPropertiesForMenuFlyoutItem()
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<MenuFlyoutItem>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindableCommandPropertiesForUnsupportedType()
 			=> Assert.Throws<ArgumentException>(
-				() => DefaultBindableProperties.GetFor(new CustomView()),
+				() => DefaultBindableProperties.GetDefaultProperty<CustomView>(),
 				"No command + command parameter properties are registered for BindableObject type XamarinFormsMarkupUnitTestsDefaultBindablePropertiesViews.CustomView" +
 				"\r\nRegister command + command parameter properties for this BindableObject type");
 
 		[Test]
 		public void RegisterDefaultBindableCommandProperties()
 		{
-			var v = new CustomViewWithCommand();
-			Assert.Throws<ArgumentException>(() => DefaultBindableProperties.GetForCommand(v));
+			Assert.Throws<ArgumentException>(() => DefaultBindableProperties.GetCommandAndCommandParameterProperty<CustomViewWithCommand>());
 
 			DefaultBindableProperties.RegisterForCommand((CustomViewWithCommand.CommandProperty, CustomViewWithCommand.CommandParameterProperty));
 		}
@@ -217,12 +69,12 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		[TearDown]
 		public override void TearDown()
 		{
-			if (DefaultBindableProperties.GetFor(typeof(CustomViewWithText)) != null)
+			if (DefaultBindableProperties.TryGetDefaultProperty<CustomViewWithText>(out _))
 			{
 				DefaultBindableProperties.Unregister(CustomViewWithText.TextProperty);
 			}
 
-			if (DefaultBindableProperties.GetForCommand(typeof(CustomViewWithCommand)) != (null, null))
+			if (DefaultBindableProperties.TryGetCommandAndCommandParameterProperty<CustomViewWithCommand>(out _, out _))
 			{
 				DefaultBindableProperties.UnregisterForCommand(CustomViewWithCommand.CommandProperty);
 			}

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/DefaultBindablePropertiesTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/DefaultBindablePropertiesTests.cs
@@ -48,7 +48,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<DerivedFromButton>(), Is.Not.Null);
 
 		[Test]
-		public void GetDefaultBindableCommandPropertiesForMenuFlyoutItem()
+		public void GetDefaultBindableCommandPropertiesForMauiDerivedType()
 			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<MenuFlyoutItem>(), Is.Not.Null);
 
 		[Test]

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/DefaultBindablePropertiesTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/DefaultBindablePropertiesTests.cs
@@ -40,16 +40,28 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		}
 
 		[Test]
+		public void GetDefaultBindablePropertiesForBuiltInType()
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<Button>(), Is.Not.Null);
+
+		[Test]
+		public void GetDefaultBindablePropertiesForDerivedType()
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<DerivedFromButton>(), Is.Not.Null);
+
+		[Test]
+		public void GetDefaultBindablePropertiesForMauiDerivedType()
+			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<MenuFlyoutItem>(), Is.Not.Null);
+
+		[Test]
 		public void GetDefaultBindableCommandPropertiesForBuiltInType()
 			=> Assert.That(DefaultBindableProperties.GetCommandAndCommandParameterProperty<Button>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindableCommandPropertiesForDerivedType()
-			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<DerivedFromButton>(), Is.Not.Null);
+			=> Assert.That(DefaultBindableProperties.GetCommandAndCommandParameterProperty<DerivedFromButton>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindableCommandPropertiesForMauiDerivedType()
-			=> Assert.That(DefaultBindableProperties.GetDefaultProperty<MenuFlyoutItem>(), Is.Not.Null);
+			=> Assert.That(DefaultBindableProperties.GetCommandAndCommandParameterProperty<MenuFlyoutItem>(), Is.Not.Null);
 
 		[Test]
 		public void GetDefaultBindableCommandPropertiesForUnsupportedType()

--- a/src/CommunityToolkit.Maui.Markup/BindableObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/BindableObjectExtensions.cs
@@ -92,7 +92,7 @@ public static class BindableObjectExtensions
 		object? fallbackValue = null) where TBindable : BindableObject
 	{
 		bindable.Bind(
-			DefaultBindableProperties.GetFor(bindable),
+			DefaultBindableProperties.GetDefaultProperty<TBindable>(),
 			path, mode, converter, converterParameter, stringFormat, source, targetNullValue, fallbackValue);
 
 		return bindable;
@@ -112,7 +112,7 @@ public static class BindableObjectExtensions
 	{
 		var converter = new FuncConverter<TSource, TDest, object>(convert, convertBack);
 		bindable.Bind(
-			DefaultBindableProperties.GetFor(bindable),
+			DefaultBindableProperties.GetDefaultProperty<TBindable>(),
 			path, mode, converter, null, stringFormat, source, targetNullValue, fallbackValue);
 
 		return bindable;
@@ -133,7 +133,7 @@ public static class BindableObjectExtensions
 	{
 		var converter = new FuncConverter<TSource, TDest, TParam>(convert, convertBack);
 		bindable.Bind(
-			DefaultBindableProperties.GetFor(bindable),
+			DefaultBindableProperties.GetDefaultProperty<TBindable>(),
 			path, mode, converter, converterParameter, stringFormat, source, targetNullValue, fallbackValue);
 
 		return bindable;
@@ -152,7 +152,7 @@ public static class BindableObjectExtensions
 		string? parameterPath = bindingContextPath,
 		object? parameterSource = null) where TBindable : BindableObject
 	{
-		(var commandProperty, var parameterProperty) = DefaultBindableProperties.GetForCommand(bindable);
+		(var commandProperty, var parameterProperty) = DefaultBindableProperties.GetCommandAndCommandParameterProperty<TBindable>();
 
 		bindable.SetBinding(commandProperty, new Binding(path: path, source: source));
 


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes a bug in `.BindCommand()` that prevented the logic from working on .NET MAUI controls that inherit from a base class that implements `CommandProperty` and `CommandParameterProperty`.

The specific example raised in #82 demonstrates that `MenuFlyoutItem` doesn't implement `CommandProperty` and `CommandParameterProperty`, but its base class [`MenuItem` does](https://github.com/dotnet/maui/blob/e38582b53564b85398588e9ecaba43e325fa04fa/src/Controls/src/Core/MenuItem.cs#L16-L22).

The logic in `.BindCommand()` uses reflection to recursively search for `CommandProperty` and `CommandParameterProperty` in a class. If it doesn't find it, it will then search the base class. However, this line of code was preventing it from searching a base class once it discovered a `Microsoft.Maui.*` class:

```cs
if (bindableObjectTypeName?.StartsWith($"{nameof(Microsoft)}.{nameof(Microsoft.Maui)}.", StringComparison.Ordinal) is true)
{
    break;
}
```

I removed this logic, and refactored the methods in `DefaultBindableProperties` to only stop recursively searching base classes once the `Microsoft.Maui.Controls.BindableObject` class is found.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #82 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This PR includes the following refactors for [`DefaultBindableProperties`](https://github.com/CommunityToolkit/Maui.Markup/compare/Enable-BindCommand-for-Base-Types?expand=1#diff-2a409a8962303a90190ca852d739b616587e6f569b0ec8954fd5f92848421fca):

#### 1 `GetFor(BindableObject bindableObject)`
  ```cs
  // Previous Method
  BindableProperty GetFor(BindableObject bindableObject);

  // Updated Method
  BindableProperty GetDefaultProperty<T>() where T : BindableObject;
  ```
  - The naming is now more descriptive of the method's job
  - Adding a generic constraint ensures that only controls implementing `BindableObject` can be checked by this method
    - I chose `BindableObject` for the constraint because a bindable property (like `CommandProperty` and `CommandParameterProperty`) can only exist in a class inheriting from `BindableObject`

#### 2 `GetFor(Type? bindableObjectType)`
  ```cs
  // Previous Method
  BindableProperty? GetFor(Type? bindableObjectType);

  // Updated Method
  bool TryGetDefaultProperty<T>([NotNullWhen(true)] out BindableProperty? defaultBindableProperty) where T : BindableObject;
  ```
  - The naming is now more descriptive of the method's job
    - It previously returned `null` when the values were not found
    - I prepended `Try*` and have it now return a `bool` with `out` parameters
  - Adding a generic constraint ensures that only controls implementing `BindableObject` can be checked by this method
    - I chose `BindableObject` for the constraint because a bindable property (like `CommandProperty` and `CommandParameterProperty`) can only exist in a class inheriting from `BindableObject`
  - Add a check for `BindableObject` in the `do/while` loop:
  ```cs
  while (bindableObjectType is not null && bindableObjectType.GetType() != typeof(BindableObject));
  ```

#### 3 `GetForCommand(BindableObject bindableObject)`
  ```cs
  // Previous Method
  (BindableProperty, BindableProperty) GetForCommand(BindableObject bindableObject);

  // Updated Method
  (BindableProperty CommandProperty, BindableProperty CommandParameterProperty) GetCommandAndCommandParameterProperty<T>() where T : BindableObject;
  ```
  - The naming is now more descriptive of the method's job
  - Adding a generic constraint ensures that only controls implementing `BindableObject` can be checked by this method
    - I chose `BindableObject` for the constraint because a bindable property (like `CommandProperty` and `CommandParameterProperty`) can only exist in a class inheriting from `BindableObject`

#### 4 `GetForCommand(Type? bindableObjectType)`
  ```cs
  // Previous Method
  (BindableProperty?, BindableProperty?) GetForCommand(Type? bindableObjectType);

  // Updated Method
  bool TryGetCommandAndCommandParameterProperty<T>([NotNullWhen(true)] out BindableProperty? commandProperty, [NotNullWhen(true)] out BindableProperty? commandParameterProperty) where T : BindableObject;
  ```
  - The naming is now more descriptive of the method's job
    - It previously returned `null` when the values were not found
    - I prepended `Try*` and have it now return a `bool` with `out` parameters
  - Adding a generic constraint ensures that only controls implementing `BindableObject` can be checked by this method
    - I chose `BindableObject` for the constraint because a bindable property (like `CommandProperty` and `CommandParameterProperty`) can only exist in a class inheriting from `BindableObject`
  - Add a check for `BindableObject` in the `do/while` loop:
  ```cs
  while (bindableObjectType is not null && bindableObjectType.GetType() != typeof(BindableObject));
  ```

#### Unit Tests

#### 1. Added Tests for .NET Maui Derived Types
```cs
[Test]
public void GetDefaultBindablePropertiesForMauiDerivedType()
	=> Assert.That(DefaultBindableProperties.GetDefaultProperty<MenuFlyoutItem>(), Is.Not.Null);

[Test]
public void GetDefaultBindableCommandPropertiesForMauiDerivedType()
	=> Assert.That(DefaultBindableProperties.GetCommandAndCommandParameterProperty<MenuFlyoutItem>(), Is.Not.Null);
```
#### 2. Removed `AllBindableElementsInCoreHaveDefaultBindablePropertyOrAreExcluded`

Refactoring the method to consume a generic type, `<T>`, forced me to remove the unit test `AllBindableElementsInCoreHaveDefaultBindablePropertyOrAreExcluded`.

This Unit Test uses reflection to find every .NET MAUI control that implements `CommandProperty` and `CommandParameterProperty` and confirms that the default bindable property exists. 

However, reflection provides the found classes as a `Type`, but the updated API requires a specific generic Type, eg `DefaultBindableProperties. GetCommandAndCommandParameterProperty<Label>()`, and we cannot convert `Type` to `<T>`.