### PR TITLE
Update `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -92,7 +92,7 @@ dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_s
 dotnet_naming_symbols.instance_fields.applicable_kinds = field
 
 dotnet_naming_style.instance_field_style.capitalization = camel_case
-dotnet_naming_style.instance_field_style.required_prefix = 
+dotnet_naming_style.instance_field_style.required_prefix =
 
 ## Static fields are camelCase
 dotnet_naming_rule.static_fields_should_be_camel_case.severity = error
@@ -104,8 +104,35 @@ dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = internal, private, protected, protected_internal, private_protected
 
 dotnet_naming_style.static_field_style.capitalization = camel_case
-dotnet_naming_style.static_field_style.required_prefix = 
+dotnet_naming_style.static_field_style.required_prefix =
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:error
+
+# CA1707: Remove the underscores from member name
+dotnet_diagnostic.CA1707.severity = none
+
+# CA1305: The behavior of 'string.Format(string, object)' could vary based on the current user's locale settings. Replace this call
+dotnet_diagnostic.CA1305.severity = suggestion
+
+# CA1822: Member does not access instance data and can be marked as static
+dotnet_diagnostic.CA1822.severity = error
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = error
+
+# CA2016: Forward the 'cancellationToken' parameter methods that take one
+dotnet_diagnostic.CA2016.severity = error
+
+# CA2208: Method passes parameter as the paramName argument to a ArgumentNullException constructor. Replace this argument with one of the method's parameter names. Note that the provided parameter name should have the exact casing as declared on the method.
+dotnet_diagnostic.CA2208.severity = error
+
+# CA1001: Type owns disposable field(s) but is not disposable
+dotnet_diagnostic.CA1001.severity = error
+
+# CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
+dotnet_diagnostic.CA1834.severity = error
+
+# CA1309: Use ordinal string comparison
+dotnet_diagnostic.CA1309.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 # CA1063: Implement IDisposable Correctly
 dotnet_diagnostic.CA1063.severity = error
 
+# CA1001: Type owns disposable field(s) but is not disposable
+dotnet_diagnostic.CA1001.severity = error
+
 # Add braces (IDE0011)
 csharp_prefer_braces = true
 dotnet_diagnostic.IDE0011.severity = error
@@ -110,11 +113,8 @@ dotnet_naming_style.static_field_style.required_prefix =
 csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:error
 
-# CA1707: Remove the underscores from member name
-dotnet_diagnostic.CA1707.severity = none
-
 # CA1305: The behavior of 'string.Format(string, object)' could vary based on the current user's locale settings. Replace this call
-dotnet_diagnostic.CA1305.severity = suggestion
+dotnet_diagnostic.CA1305.severity = error
 
 # CA1822: Member does not access instance data and can be marked as static
 dotnet_diagnostic.CA1822.severity = error
@@ -127,9 +127,6 @@ dotnet_diagnostic.CA2016.severity = error
 
 # CA2208: Method passes parameter as the paramName argument to a ArgumentNullException constructor. Replace this argument with one of the method's parameter names. Note that the provided parameter name should have the exact casing as declared on the method.
 dotnet_diagnostic.CA2208.severity = error
-
-# CA1001: Type owns disposable field(s) but is not disposable
-dotnet_diagnostic.CA1001.severity = error
 
 # CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
 dotnet_diagnostic.CA1834.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -113,9 +113,6 @@ dotnet_naming_style.static_field_style.required_prefix =
 csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:error
 
-# CA1305: The behavior of 'string.Format(string, object)' could vary based on the current user's locale settings. Replace this call
-dotnet_diagnostic.CA1305.severity = error
-
 # CA1822: Member does not access instance data and can be marked as static
 dotnet_diagnostic.CA1822.severity = error
 
@@ -131,5 +128,5 @@ dotnet_diagnostic.CA2208.severity = error
 # CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
 dotnet_diagnostic.CA1834.severity = error
 
-# CA1309: Use ordinal string comparison
-dotnet_diagnostic.CA1309.severity = error
+# IDE0220: Add explicit cast
+dotnet_diagnostic.IDE0220.severity = error

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <Project>
-	<PropertyGroup>
-		<LangVersion>latest</LangVersion>
-		<Nullable>enable</Nullable>
-		<!--CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] -->
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <!--CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] -->
     <!--CS1571: XML comment on [construct] has a duplicate param tag for [parameter] -->
     <!--CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name -->
     <!--CS1573: Parameter has no matching param tag in the XML comment -->
     <!--CS1574: XML comment has cref attribute that could not be resolved-->
     <!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
     <WarningsAsErrors>nullable,CS1570,CS1571,CS1572,CS1573,CS1574,CS1734</WarningsAsErrors>
-		<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
-		<GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-	</PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="CommunityToolkit.Maui.Markup.UnitTests" />


### PR DESCRIPTION
 ### Description of Change ###

This PR mirrors the updates to `.editorconfig` on `CommunityToolkit/Maui`: https://github.com/CommunityToolkit/Maui/pull/563

This PR adds the following rules:
- `.editorconfig`
  - CA1001: Type owns disposable field(s) but is not disposable
    - Ensures that we continue to implement `IDisposable` correctly
  - CA1822: Member does not access instance data and can be marked as static
    - Improve performance to avoid unnecessary stack allocations
  - CA1050: Declare types in namespaces
    - Ensures each file has a namespace declared
  - CA2016: Forward the 'CancellationToken' parameter methods that take one
    - Ensures we properly propagate `CancellationToken`
  - CA2208: Method passes parameter as the paramName argument to a ArgumentNullException constructor. Replace this argument with one of the method's parameter names. Note that the provided parameter name should have the exact casing as declared on the method.
    -  Ensures we properly pass in the arguments to `ArgumentNullException`; the constructor accepts `(string paramName, string message)` and sometimes the parameters can be accidentally swapped
  - CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
    - Small performance improvement for `StringBuilder`
  - IDE0220: Add explicit cast
    - Prevents implicit casting
    - Example:
      ```cs
      foreach (Match? match in matches) // `MatchCollection matches` is an `IEnumerable` whose content can be implicitly cast to `Match`
      // changes to
      foreach (var match in matches.Cast<Match?>()) // Ensures we continue to cast to `Match` if/when the implicit cast in `MatchCollection` changes
      ```
- `Directory.build.props`
  - <NoWarn>NETSDK1023</NoWarn>
  - Resolves #558

 ### Additional information ###