### PR TITLE
[CommunityToolkit.Maui.Markup.Sample] Replace `Refit` + `Polly` with `Microsoft.Extensions.Http.Polly` and `Refit.HttpClientFactory`

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -42,9 +42,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Maui" Version="1.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="Refit" Version="6.3.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.9" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Services/HackerNewsApiService.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Services/HackerNewsApiService.cs
@@ -8,13 +8,6 @@ class HackerNewsAPIService
 
 	public HackerNewsAPIService(IHackerNewsApi hackerNewslient) => hackerNewsClient = hackerNewslient;
 
-	public Task<StoryModel> GetStory(long storyId) => AttemptAndRetry(() => hackerNewsClient.GetStory(storyId));
-	public Task<IReadOnlyList<long>> GetTopStoryIDs() => AttemptAndRetry(() => hackerNewsClient.GetTopStoryIDs());
-
-	static Task<T> AttemptAndRetry<T>(Func<Task<T>> action, int numRetries = 3)
-	{
-		return Policy.Handle<Exception>().WaitAndRetryAsync(numRetries, pollyRetryAttempt).ExecuteAsync(action);
-
-		static TimeSpan pollyRetryAttempt(int attemptNumber) => TimeSpan.FromSeconds(Math.Pow(2, attemptNumber));
-	}
+	public Task<StoryModel> GetStory(long storyId) => hackerNewsClient.GetStory(storyId);
+	public Task<IReadOnlyList<long>> GetTopStoryIDs() => hackerNewsClient.GetTopStoryIDs();
 }


### PR DESCRIPTION
To demonstrate best practices for .NET MAUI apps that utilize HttpClient, this PR replaces the following NuGet Packages:
- `Refit` -> `Refit.HttpClientFactory`
- `Polly` -> `Microsoft.Extensions.Http.Polly`

Because .NET MAUI supports dependency injection, we can leverage `Refit.HttpClientFactory` to easily implement REST API requests and `Microsoft.Extensions.Http.Polly` to add automatic error handling policies. In the updated code below, when HttpClient fails it will now automatically retry to connect to the URL 3 times using an exponential backoff of 2<sup>n</sup> seconds. This is ideal for flaky mobile internet connections where a user's device may switch cellular towers or lose a Wifi connection.

```cs
builder.Services.AddRefitClient<IHackerNewsApi>()
	.ConfigureHttpClient(client => client.BaseAddress = new Uri("https://hacker-news.firebaseio.com/v0"))
	.AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(3, sleepDurationProvider));

static TimeSpan sleepDurationProvider(int attemptNumber) => TimeSpan.FromSeconds(Math.Pow(2, attemptNumber));
```

