### PR TITLE
[Sample App] Add `IDisposable`

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsDetailPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsDetailPage.cs
@@ -2,7 +2,7 @@
 
 namespace CommunityToolkit.Maui.Markup.Sample.Pages;
 
-class NewsDetailPage : BaseContentPage<NewsDetailViewModel>
+sealed class NewsDetailPage : BaseContentPage<NewsDetailViewModel>
 {
 	public NewsDetailPage(NewsDetailViewModel newsDetailViewModel) : base(newsDetailViewModel, newsDetailViewModel.Title)
 	{

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommunityToolkit.Maui.Markup.Sample.Pages;
 
-class NewsPage : BaseContentPage<NewsViewModel>
+sealed class NewsPage : BaseContentPage<NewsViewModel>
 {
 	readonly IDispatcher dispatcher;
 	readonly RefreshView refreshView;

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -2,7 +2,7 @@
 
 namespace CommunityToolkit.Maui.Markup.Sample.Pages;
 
-class SettingsPage : BaseContentPage<SettingsViewModel>
+sealed class SettingsPage : BaseContentPage<SettingsViewModel>
 {
 	public SettingsPage(SettingsViewModel settingsViewModel) : base(settingsViewModel, "Settings")
 	{

--- a/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/NewsDetailViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/NewsDetailViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommunityToolkit.Maui.Markup.Sample.ViewModels;
 
-partial class NewsDetailViewModel : BaseViewModel, IQueryAttributable
+sealed partial class NewsDetailViewModel : BaseViewModel, IQueryAttributable
 {
 	readonly IBrowser browser;
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/NewsViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/NewsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommunityToolkit.Maui.Markup.Sample.ViewModels;
 
-partial class NewsViewModel : BaseViewModel
+sealed partial class NewsViewModel : BaseViewModel, IDisposable
 {
 	readonly IDispatcher dispatcher;
 	readonly SettingsService settingsService;
@@ -27,6 +27,11 @@ partial class NewsViewModel : BaseViewModel
 	}
 
 	public ObservableCollection<StoryModel> TopStoryCollection { get; } = new();
+
+	public void Dispose()
+	{
+		insertIntoSortedCollectionSemaphore.Dispose();
+	}
 
 	[RelayCommand]
 	async Task PullToRefresh()

--- a/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/SettingsViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommunityToolkit.Maui.Markup.Sample.ViewModels;
 
-partial class SettingsViewModel : BaseViewModel
+sealed partial class SettingsViewModel : BaseViewModel
 {
 	readonly SettingsService settingsService;
 


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes the following build error:
> NewsViewModel.cs(15,15): Error CA1001: Type 'NewsViewModel' owns disposable field(s) 'insertIntoSortedCollectionSemaphore' but is not disposable (CA1001) (CommunityToolkit.Maui.Markup.Sample)

This PR also adds `sealed` to each Page + ViewModel class to reduce the complexity of the `IDisposable` implementation and to [improve performance](https://www.meziantou.net/performance-benefits-of-sealed-class.htm).