### PR TITLE
Support all inherited `ITextAlignment` for `TextAlignmentExtensions`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ variables:
   PathToCommunityToolkitCsproj: 'src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj'
   PathToCommunityToolkitSampleCsproj: 'samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj'
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj'
+  PathToCommunityToolkitSourceGeneratorsCsproj: 'src/CommunityToolkit.Maui.Markup.SourceGenerators/CommunityToolkit.Maui.Markup.SourceGenerators.csproj'
   XcodeVersion: '14.0.1'
   ShouldCheckDependencies: true
   
@@ -79,15 +80,6 @@ jobs:
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
 
-      # test
-      - task: DotNetCoreCLI@2
-        displayName: 'Run Unit Tests'
-        inputs:
-          command: 'test'
-          projects: '$(PathToCommunityToolkitUnitTestCsproj)'
-          arguments: '--configuration Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
-          publishTestResults: false    
-
       - task: PublishTestResults@2
         displayName: 'Publish Test Results'
         inputs:
@@ -101,13 +93,43 @@ jobs:
           summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
           failIfCoverageEmpty: true
 
-      # build sample
+      # build
       - task: VSBuild@1
-        displayName: 'Build Markup CommunityToolkit.Maui.Markup.Sample'
+        displayName: 'Build CommunityToolkit.Maui.Markup.SourceGenerators'
+        inputs:
+          solution: '$(PathToCommunityToolkitSourceGeneratorsCsproj)'
+          configuration: 'Release'
+          msbuildArgs: '/restore'
+
+      - task: VSBuild@1
+        displayName: 'Build CommunityToolkit.Maui.Markup'
+        inputs:
+          solution: '$(PathToCommunityToolkitCsproj)'
+          configuration: 'Release'
+          msbuildArgs: '/restore'
+
+      - task: VSBuild@1
+        displayName: 'Build CommunityToolkit.Maui.Markup.Sample'
         inputs:
           solution: '$(PathToCommunityToolkitSampleCsproj)'
           configuration: 'Release'
           msbuildArgs: '/restore'
+
+      - task: VSBuild@1
+        displayName: 'Build CommunityToolkit.Maui.Markup.UnitTests'
+        inputs:
+          solution: '$(PathToCommunityToolkitUnitTestCsproj)'
+          configuration: 'Release'
+          msbuildArgs: '/restore'
+
+      # test
+      - task: DotNetCoreCLI@2
+        displayName: 'Run Unit Tests'
+        inputs:
+          command: 'test'
+          projects: '$(PathToCommunityToolkitUnitTestCsproj)'
+          arguments: '--configuration Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
+          publishTestResults: false    
 
       # pack
       - task: VSBuild@1
@@ -209,31 +231,45 @@ jobs:
         inputs:
           packageType: 'sdk'
           version: '$(NET_VERSION)'
+
       - task: CmdLine@2
         displayName: 'Install .NET MAUI workload'
-
         inputs:
           script: 'dotnet workload install maui'
+
       - task: CmdLine@2
         displayName: 'Restore NuGet Packages'
         inputs:
           script: 'dotnet restore $(PathToCommunityToolkitCsproj)'
+      
+      # build
+      - task: CmdLine@2
+        displayName: 'Build CommunityToolkit.Maui.Markup.SourceGenerators'
+        inputs:
+          script: dotnet build $(PathToCommunityToolkitSourceGeneratorsCsproj) -c Release
 
       - task: CmdLine@2
-        displayName: 'Build Community Toolkit'
+        displayName: 'Build CommunityToolkit.Maui.Markup'
         inputs:
           script: dotnet build $(PathToCommunityToolkitCsproj) -c Release
 
       - task: CmdLine@2
-        displayName: 'Build Community Toolkit Sample'
+        displayName: 'Build CommunityToolkit.Maui.Markup.Sample'
         inputs:
           script: dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release
 
+      - task: CmdLine@2
+        displayName: 'Build CommunityToolkit.Maui.Markup.UnitTests'
+        inputs:
+          script: dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release
+
+      # test
       - task: CmdLine@2
         displayName: 'Run Unit Tests'
         inputs:
           script: dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release
 
+      # pack
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit NuGets'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,19 +80,6 @@ jobs:
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
 
-      - task: PublishTestResults@2
-        displayName: 'Publish Test Results'
-        inputs:
-          testResultsFormat: VSTest
-          testResultsFiles: '**/*.trx'
-          searchFolder: $(Agent.TempDirectory)
-      - task: PublishCodeCoverageResults@1
-        displayName: 'Publish Code Coverage Results'
-        inputs:
-          codeCoverageTool: 'Cobertura'
-          summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
-          failIfCoverageEmpty: true
-
       # build
       - task: VSBuild@1
         displayName: 'Build CommunityToolkit.Maui.Markup.SourceGenerators'
@@ -129,7 +116,21 @@ jobs:
           command: 'test'
           projects: '$(PathToCommunityToolkitUnitTestCsproj)'
           arguments: '--configuration Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
-          publishTestResults: false    
+          publishTestResults: false  
+
+      - task: PublishTestResults@2
+        displayName: 'Publish Test Results'
+        inputs:
+          testResultsFormat: VSTest
+          testResultsFiles: '**/*.trx'
+          searchFolder: $(Agent.TempDirectory)
+          
+      - task: PublishCodeCoverageResults@1
+        displayName: 'Publish Code Coverage Results'
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+          failIfCoverageEmpty: true 
 
       # pack
       - task: VSBuild@1

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -49,6 +49,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
+    <ProjectReference Include="..\..\src\CommunityToolkit.Maui.Markup.SourceGenerators\CommunityToolkit.Maui.Markup.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/Diagnostics/TextAlignmentDiagnostics.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/Diagnostics/TextAlignmentDiagnostics.cs
@@ -16,10 +16,26 @@ class TextAlignmentDiagnostics
 
 	public static readonly DiagnosticDescriptor MauiReferenceIsMissing = new(
 		   "MMCT002",
-		   "Was not possible to find Microsoft.Maui.ITextAlignment",
+		   "Unable to find Microsoft.Maui.ITextAlignment",
 		   "Please make sure that your project is referencing Microsoft.Maui",
 		   category,
 		   DiagnosticSeverity.Error,
+		   true);
+
+	public static readonly DiagnosticDescriptor InvalidClassDeclarationSyntax = new(
+		   "MMCT003",
+		   "Unable to get information from the Class",
+		   "Please make sure that the code inside '{0}' has not error, the TextColorTo methods will not be generated for this file",
+		   category,
+		   DiagnosticSeverity.Info,
+		   true);
+
+	public static readonly DiagnosticDescriptor InvalidModifierAccess = new(
+		   "MMCT004",
+		   "Class marked with invalid modifier access",
+		   "TextColorTo only supports public and internal classes inheriting from ITextStyle, please fix '{0}'",
+		   category,
+		   DiagnosticSeverity.Info,
 		   true);
 
 }

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/CompilationExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/CompilationExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CommunityToolkit.Maui.Markup.SourceGenerators;
+
+static class CompilationExtensions
+{
+	public static TSymbol? GetSymbol<TSymbol>(this Compilation compilation, BaseTypeDeclarationSyntax declarationSyntax)
+		where TSymbol : ISymbol
+	{
+		var model = compilation.GetSemanticModel(declarationSyntax.SyntaxTree);
+		return (TSymbol?)model.GetDeclaredSymbol(declarationSyntax);
+	}
+}

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -91,19 +91,13 @@ static class NamespaceSymbolExtensions
 
 		foreach (var typeParameterSymbol in type.TypeParameters)
 		{
-			bool isFirstConstraint = true;
-
 			if (typeParameterSymbol.HasNotNullConstraint)
 			{
 				constraints.Append("notnull");
-
-				isFirstConstraint = false;
 			}
 			else if (typeParameterSymbol.HasUnmanagedTypeConstraint)
 			{
 				constraints.Append("unmanaged");
-
-				isFirstConstraint = false;
 			}
 			else if (typeParameterSymbol.HasReferenceTypeConstraint)
 			{
@@ -113,25 +107,17 @@ static class NamespaceSymbolExtensions
 				{
 					constraints.Append("?");
 				}
-
-				isFirstConstraint = false;
 			}
 			else if (typeParameterSymbol.HasValueTypeConstraint)
 			{
 				constraints.Append("struct");
-
-				isFirstConstraint = false;
 			}
 
 			foreach (INamedTypeSymbol contstraintType in typeParameterSymbol.ConstraintTypes.Cast<INamedTypeSymbol>())
 			{
-				if (!isFirstConstraint)
+				if (constraints.Length > 0)
 				{
 					constraints.Append(", ");
-				}
-				else
-				{
-					isFirstConstraint = false;
 				}
 
 				constraints.Append(contstraintType.GetFullTypeString());
@@ -139,17 +125,17 @@ static class NamespaceSymbolExtensions
 
 			if (typeParameterSymbol.HasConstructorConstraint)
 			{
-				if (!isFirstConstraint)
+				if (constraints.Length > 0)
 				{
 					constraints.Append(", ");
 				}
+
 				constraints.Append("new()");
 			}
 
 			if (constraints.Length > 0)
 			{
-				result.Append($"where " + typeParameterSymbol.Name + " : " + constraints + @"
-");
+				result.Append($"where " + typeParameterSymbol.Name + " : " + constraints + " \n\t");
 				constraints.Clear();
 			}
 		}

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -122,6 +122,11 @@ static class NamespaceSymbolExtensions
 
 				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 				constraints.Append(contstraintType.ToDisplayString(symbolDisplayFormat));
+
+				if (contstraintType.NullableAnnotation is NullableAnnotation.Annotated)
+				{
+					constraints.Append("?");
+				}
 			}
 
 			if (typeParameterSymbol.HasConstructorConstraint)

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -120,13 +120,9 @@ static class NamespaceSymbolExtensions
 					constraints.Append(", ");
 				}
 
-				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+																	miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 				constraints.Append(contstraintType.ToDisplayString(symbolDisplayFormat));
-
-				if (contstraintType.NullableAnnotation is NullableAnnotation.Annotated)
-				{
-					constraints.Append("?");
-				}
 			}
 
 			if (typeParameterSymbol.HasConstructorConstraint)

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -103,7 +103,7 @@ static class NamespaceSymbolExtensions
 			{
 				constraints.Append("class");
 
-				if (typeParameterSymbol.ReferenceTypeConstraintNullableAnnotation == NullableAnnotation.Annotated)
+				if (typeParameterSymbol.ReferenceTypeConstraintNullableAnnotation is NullableAnnotation.Annotated)
 				{
 					constraints.Append("?");
 				}
@@ -120,7 +120,8 @@ static class NamespaceSymbolExtensions
 					constraints.Append(", ");
 				}
 
-				constraints.Append(contstraintType.GetFullTypeString());
+				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+				constraints.Append(contstraintType.ToDisplayString(symbolDisplayFormat));
 			}
 
 			if (typeParameterSymbol.HasConstructorConstraint)

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -109,7 +109,7 @@ using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 
-namespace " + textAlignmentClass.Namespace + @"
+namespace CommunityToolkit.Maui.Markup
 {
 	/// <summary>
 	/// Extension Methods for <see cref=""ITextAlignment""/>

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -125,8 +125,10 @@ namespace CommunityToolkit.Maui.Markup
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+			if (textAlignmentControl is not ITextAlignment)
+			{
+				throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+			}
 
 			textAlignmentControl.HorizontalTextAlignment = TextAlignment.Start;
 			return textAlignmentControl;
@@ -141,8 +143,10 @@ namespace CommunityToolkit.Maui.Markup
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+			if (textAlignmentControl is not ITextAlignment)
+			{
+				throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+			}
 
 			textAlignmentControl.HorizontalTextAlignment = TextAlignment.Center;
 			return textAlignmentControl;
@@ -157,8 +161,10 @@ namespace CommunityToolkit.Maui.Markup
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+			if (textAlignmentControl is not ITextAlignment)
+			{
+				throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+			}
 
 			textAlignmentControl.HorizontalTextAlignment = TextAlignment.End;
 			return textAlignmentControl;
@@ -173,8 +179,10 @@ namespace CommunityToolkit.Maui.Markup
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+			if (textAlignmentControl is not ITextAlignment)
+			{
+				throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+			}
 
 			textAlignmentControl.VerticalTextAlignment = TextAlignment.Start;
 			return textAlignmentControl;
@@ -189,8 +197,10 @@ namespace CommunityToolkit.Maui.Markup
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+			if (textAlignmentControl is not ITextAlignment)
+			{
+				throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+			}
 
 			textAlignmentControl.VerticalTextAlignment = TextAlignment.Center;
 			return textAlignmentControl;
@@ -205,8 +215,10 @@ namespace CommunityToolkit.Maui.Markup
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+			if (textAlignmentControl is not ITextAlignment)
+			{
+				throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+			}
 
 			textAlignmentControl.VerticalTextAlignment = TextAlignment.End;
 			return textAlignmentControl;
@@ -241,8 +253,10 @@ namespace CommunityToolkit.Maui.Markup
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+				if (textAlignmentControl is not ITextAlignment)
+				{
+					throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+				}
 
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.Start;
 			    return textAlignmentControl;
@@ -257,8 +271,10 @@ namespace CommunityToolkit.Maui.Markup
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+				if (textAlignmentControl is not ITextAlignment)
+				{
+					throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+				}
 
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.End;
 			    return textAlignmentControl;
@@ -284,8 +300,10 @@ namespace CommunityToolkit.Maui.Markup
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+				if (textAlignmentControl is not ITextAlignment)
+				{
+					throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+				}
 
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.End;
 			    return textAlignmentControl;
@@ -300,8 +318,10 @@ namespace CommunityToolkit.Maui.Markup
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
-				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
-					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+				if (textAlignmentControl is not ITextAlignment)
+				{
+					throw new ArgumentException($""Element must implement {nameof(ITextAlignment)}"", nameof(textAlignmentControl));
+				}
 
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.Start;
 			    return textAlignmentControl;

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -109,7 +109,7 @@ using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 
-namespace "+ textAlignmentClass.Namespace + @"
+namespace CommunityToolkit.Maui.Markup
 {
 	/// <summary>
 	/// Extension Methods for <see cref=""ITextAlignment""/>
@@ -120,8 +120,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.Start""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Start""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextStart" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Start""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextStart" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -136,8 +136,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.Center""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenterHorizontal" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenterHorizontal" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -152,8 +152,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.End""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.End""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextEnd" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.End""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextEnd" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -168,8 +168,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.VerticalTextAlignment""/> = <see cref=""TextAlignment.Start""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Start""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextTop" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Start""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextTop" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -184,8 +184,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.VerticalTextAlignment""/> = <see cref=""TextAlignment.Center""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenterVertical" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenterVertical" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -200,8 +200,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.VerticalTextAlignment""/> = <see cref=""TextAlignment.End""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.End""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextBottom" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.End""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextBottom" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
 			ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -216,8 +216,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// <see cref=""ITextAlignment.VerticalTextAlignment""/> = <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.Center""/>
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
-		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
-		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenter" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		/// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
+		public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenter" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 			=> textAlignmentControl.TextCenterHorizontal().TextCenterVertical();
 	}
 
@@ -236,8 +236,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.Start""/>
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
-		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.Start""/></returns>
-		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		    /// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.Start""/></returns>
+		    public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -252,8 +252,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.End""/>
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
-		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.End""/></returns>
-		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		    /// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.End""/></returns>
+		    public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -279,8 +279,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.End""/>
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
-		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.End""/></returns>
-		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		    /// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.End""/></returns>
+		    public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 
@@ -295,8 +295,8 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.Start""/>
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
-		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.Start""/></returns>
-		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
+		    /// <returns>" + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.Start""/></returns>
+		    public static " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
 				ArgumentNullException.ThrowIfNull(textAlignmentControl);
 

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -109,7 +109,7 @@ using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 
-namespace " + textStyleClass.Namespace + @"
+namespace " + textAlignmentClass.Namespace + @"
 {
 	/// <summary>
 	/// Extension Methods for <see cref=""ITextAlignment""/>

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -109,7 +109,7 @@ using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 
-namespace CommunityToolkit.Maui.Markup
+namespace " + textStyleClass.Namespace + @"
 {
 	/// <summary>
 	/// Extension Methods for <see cref=""ITextAlignment""/>

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -105,6 +105,7 @@ class TextAlignmentExtensionsGenerator : IIncrementalGenerator
 // See: CommunityToolkit.Maui.Markup.SourceGenerators.TextAlignmentGenerator
 #nullable enable
 
+using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 
@@ -120,8 +121,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Start""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextStart" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextStart" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
+			ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			textAlignmentControl.HorizontalTextAlignment = TextAlignment.Start;
 			return textAlignmentControl;
 		}
@@ -131,8 +137,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextCenterHorizontal" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenterHorizontal" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
+			ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			textAlignmentControl.HorizontalTextAlignment = TextAlignment.Center;
 			return textAlignmentControl;
 		}
@@ -142,8 +153,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.End""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextEnd" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextEnd" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
+			ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			textAlignmentControl.HorizontalTextAlignment = TextAlignment.End;
 			return textAlignmentControl;
 		}
@@ -153,8 +169,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Start""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextTop" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextTop" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
+			ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			textAlignmentControl.VerticalTextAlignment = TextAlignment.Start;
 			return textAlignmentControl;
 		}
@@ -164,8 +185,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextCenterVertical" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenterVertical" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
+			ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			textAlignmentControl.VerticalTextAlignment = TextAlignment.Center;
 			return textAlignmentControl;
 		}
@@ -175,8 +201,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.End""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextBottom" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextBottom" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		{
+			ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+			if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+				throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			textAlignmentControl.VerticalTextAlignment = TextAlignment.End;
 			return textAlignmentControl;
 		}
@@ -186,7 +217,7 @@ namespace "+ textAlignmentClass.Namespace + @"
 		/// </summary>
 		/// <param name=""textAlignmentControl""></param>
 		/// <returns>" + textAlignmentClass.ClassName + @" with added <see cref=""TextAlignment.Center""/></returns>
-		public static " + textAlignmentClass.ClassName + @" TextCenter" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextCenter" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 			=> textAlignmentControl.TextCenterHorizontal().TextCenterVertical();
 	}
 
@@ -206,8 +237,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
 		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.Start""/></returns>
-		    public static " + textAlignmentClass.ClassName + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
+				ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.Start;
 			    return textAlignmentControl;
 		    }
@@ -217,8 +253,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
 		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.End""/></returns>
-		    public static " + textAlignmentClass.ClassName + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
+				ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.End;
 			    return textAlignmentControl;
 		    }
@@ -239,8 +280,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
 		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.End""/></returns>
-		    public static " + textAlignmentClass.ClassName + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextLeft" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
+				ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.End;
 			    return textAlignmentControl;
 		    }
@@ -250,8 +296,13 @@ namespace "+ textAlignmentClass.Namespace + @"
 		    /// </summary>
 		    /// <param name=""textAlignmentControl""></param>
 		    /// <returns>" + textAlignmentClass.ClassName + @" with <see cref=""TextAlignment.Start""/></returns>
-		    public static " + textAlignmentClass.ClassName + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)
+		    public static " + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" TextRight" + textAlignmentClass.GenericArguments + "(this " + textAlignmentClass.Namespace + "." + textAlignmentClass.ClassName + textAlignmentClass.GenericArguments + @" textAlignmentControl)" + textAlignmentClass.GenericConstraints + @"
 		    {
+				ArgumentNullException.ThrowIfNull(textAlignmentControl);
+
+				if (textAlignmentControl is not Microsoft.Maui.ITextAlignment)
+					throw new ArgumentException($""Element must implement {nameof(Microsoft.Maui.ITextAlignment)}"", nameof(textAlignmentControl));
+
 			    textAlignmentControl.HorizontalTextAlignment = TextAlignment.Start;
 			    return textAlignmentControl;
 		    }

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -50,9 +50,9 @@ class TextAlignmentExtensionsGenerator : IIncrementalGenerator
 		var textAlignmentClassList = new List<(string ClassName, string ClassAcessModifier, string Namespace, string GenericArguments, string GenericConstraints)>();
 
 		// Collect Microsoft.Maui.Controls that Implement ITextAlignment
-		var mauiTextStyleImplementors = mauiControlsAssemblySymbolProvider.GlobalNamespace.GetNamedTypeSymbols().Where(x => x.AllInterfaces.Contains(textAlignmentSymbol, SymbolEqualityComparer.Default));
+		var mauiTextAlignmentImplementors = mauiControlsAssemblySymbolProvider.GlobalNamespace.GetNamedTypeSymbols().Where(x => x.AllInterfaces.Contains(textAlignmentSymbol, SymbolEqualityComparer.Default));
 
-		foreach (var namedTypeSymbol in mauiTextStyleImplementors)
+		foreach (var namedTypeSymbol in mauiTextAlignmentImplementors)
 		{
 			textAlignmentClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetGenericTypeConstraintsAsString()));
 		}
@@ -68,9 +68,9 @@ class TextAlignmentExtensionsGenerator : IIncrementalGenerator
 				continue;
 			}
 
-			// If the control inherits from a Maui control that implements ITextStyle, we don't need to generate a extension method for it.
-			// We just generate a method if the Control is a new implementation of ITextStyle and IAnimatable
-			var doesContainSymbolBaseType = mauiTextStyleImplementors.ContainsSymbolBaseType(declarationSymbol);
+			// If the control inherits from a Maui control that implements ITextAlignment, we don't need to generate a extension method for it.
+			// We just generate a method if the Control is a new implementation of ITextAlignment and IAnimatable
+			var doesContainSymbolBaseType = mauiTextAlignmentImplementors.ContainsSymbolBaseType(declarationSymbol);
 
 			if (!doesContainSymbolBaseType
 				&& declarationSymbol.AllInterfaces.Contains(textAlignmentSymbol, SymbolEqualityComparer.Default))

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CommunityToolkit.Maui.Markup\CommunityToolkit.Maui.Markup.csproj" />
+    <ProjectReference Include="..\CommunityToolkit.Maui.Markup.SourceGenerators\CommunityToolkit.Maui.Markup.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ICustomTextAlignment.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ICustomTextAlignment.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Maui;
+
+namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
+{
+	// Ensures custom ITextAlignment interfaces are supported
+	interface ICustomTextAlignment : ITextAlignment
+	{
+
+	}
+}

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ICustomTextAlignment.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ICustomTextAlignment.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.Maui;
-
-namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle;
-
-// Ensures custom ITextAlignment interfaces are supported
-interface ICustomTextAlignment : ITextAlignment
-{
-
-}

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ICustomTextAlignment.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ICustomTextAlignment.cs
@@ -1,10 +1,9 @@
 ﻿using Microsoft.Maui;
 
-namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
-{
-	// Ensures custom ITextAlignment interfaces are supported
-	interface ICustomTextAlignment : ITextAlignment
-	{
+namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle;
 
-	}
+// Ensures custom ITextAlignment interfaces are supported
+interface ICustomTextAlignment : ITextAlignment
+{
+
 }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Maui.Markup.UnitTests.Base;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 
 namespace CommunityToolkit.Maui.Markup.UnitTests
@@ -56,7 +57,31 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 				.Italic());
 		}
 
+		[Test]
+		public void SupportCustomTextAlignment()
+		{
+			Assert.IsInstanceOf<CustomTextAlignmentControl>(
+				new CustomTextAlignmentControl()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter()
+				.FontSize(8.0)
+				.Bold()
+				.Italic());
+		}
+
 		class DerivedFromSearchBar : SearchBar { }
+	}
+
+	class CustomTextAlignmentControl : ITextAlignment
+	{
+		public TextAlignment HorizontalTextAlignment { get; set; } = TextAlignment.Center;
+
+		public TextAlignment VerticalTextAlignment { get; set; } = TextAlignment.Center;
 	}
 }
 
@@ -75,6 +100,49 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		[Test]
 		public void TextRight()
 			=> TestPropertiesSet(l => l.TextRight(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End));
+
+		[Test]
+		public void SupportDerivedFromBindable()
+		{
+			Assert.IsInstanceOf<DerivedFromEntry>(
+				new DerivedFromEntry()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter()
+				.FontSize(8.0)
+				.Bold()
+				.Italic());
+		}
+
+		[Test]
+		public void SupportCustomTextAlignment()
+		{
+			Assert.IsInstanceOf<LeftToRightCustomTextAlignmentControl>(
+				new CustomTextAlignmentControl()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter()
+				.FontSize(8.0)
+				.Bold()
+				.Italic());
+		}
+
+		class DerivedFromEntry : Entry { }
+	}
+
+	class LeftToRightCustomTextAlignmentControl : ITextAlignment
+	{
+		public TextAlignment HorizontalTextAlignment { get; set; } = TextAlignment.Center;
+
+		public TextAlignment VerticalTextAlignment { get; set; } = TextAlignment.Center;
 	}
 }
 
@@ -93,5 +161,137 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		[Test]
 		public void TextRight()
 			=> TestPropertiesSet(l => l.TextRight(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start));
+
+		[Test]
+		public void SupportDerivedFromBindable()
+		{
+			Assert.IsInstanceOf<DerivedFromEditor>(
+				new DerivedFromEditor()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter()
+				.FontSize(8.0)
+				.Bold()
+				.Italic());
+		}
+
+		[Test]
+		public void SupportCustomTextAlignment()
+		{
+			Assert.IsInstanceOf<RightToLeftCustomTextAlignmentControl>(
+				new CustomTextAlignmentControl()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter()
+				.FontSize(8.0)
+				.Bold()
+				.Italic());
+		}
+
+		class DerivedFromEditor : Editor { }
+	}
+
+	class RightToLeftCustomTextAlignmentControl : ITextAlignment
+	{
+		public TextAlignment HorizontalTextAlignment { get; set; } = TextAlignment.Center;
+
+		public TextAlignment VerticalTextAlignment { get; set; } = TextAlignment.Center;
+	}
+}
+
+namespace CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions
+{
+	public class PublicTextStyleView : View, ICustomTextAlignment
+	{
+		public TextAlignment HorizontalTextAlignment { get; set; }
+
+		public TextAlignment VerticalTextAlignment { get; set; }
+	}
+
+	class InternalTextStyleView : View, ICustomTextAlignment
+	{
+		public TextAlignment HorizontalTextAlignment { get; set; }
+
+		public TextAlignment VerticalTextAlignment { get; set; }
+	}
+
+	// Ensures custom ITextAlignment interfaces are supported
+	interface ICustomTextAlignment : ITextAlignment
+	{
+
+	}
+
+	public interface ISomeInterface
+	{
+
+	}
+
+	public class ClassConstraintWithInterface : ISomeInterface
+	{
+
+	}
+
+	public class ClassConstraint
+	{
+
+	}
+
+	class MyGenericPicker<T> : Picker
+	{
+
+	}
+
+	public record RecordClassContstraint
+	{
+
+	}
+
+
+	public readonly record struct RecordStructContstraint
+	{
+
+	}
+
+	class MoreGenericPicker<T> : MyGenericPicker<T>
+	{
+
+	}
+
+	public struct StructConstraint
+	{
+
+	}
+
+	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM> : View, ITextAlignment
+		where TA : notnull, ISomeInterface
+		where TB : class
+		where TC : struct
+		where TD : class, ISomeInterface, new()
+		//TE has no constraints 
+		where TF : notnull
+		where TG : unmanaged
+		where TH : ISomeInterface?
+		where TI : class?
+		where TJ : ISomeInterface
+		where TK : new()
+		where TL : class
+		where TM : struct
+	{
+
+	}
+
+	class BrandNewControl : View, ITextAlignment
+	{
+		public TextAlignment HorizontalTextAlignment { get; set; }
+
+		public TextAlignment VerticalTextAlignment { get; set; }
 	}
 }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -1,9 +1,7 @@
-﻿using System.Threading.Tasks;
-using CommunityToolkit.Maui.Markup.UnitTests.Base;
+﻿using CommunityToolkit.Maui.Markup.UnitTests.Base;
 using CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 using NUnit.Framework;
 
 namespace CommunityToolkit.Maui.Markup.UnitTests
@@ -236,7 +234,6 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 namespace CommunityToolkit.Maui.Markup.UnitTests
 {
 	using CommunityToolkit.Maui.Markup.RightToLeft;
-	using CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions;
 
 	[TestFixture]
 	class RightToLeftTextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using NUnit.Framework;
+using Unique.Namespace.To.Test.Interface;
 
 namespace CommunityToolkit.Maui.Markup.UnitTests
 {
@@ -311,11 +312,6 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions
 
 	}
 
-	public interface ISomeInterface
-	{
-
-	}
-
 	public class ClassConstraintWithInterface : ISomeInterface
 	{
 
@@ -377,5 +373,13 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions
 		public TextAlignment HorizontalTextAlignment { get; set; }
 
 		public TextAlignment VerticalTextAlignment { get; set; }
+	}
+}
+
+namespace Unique.Namespace.To.Test.Interface
+{
+	public interface ISomeInterface
+	{
+
 	}
 }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -126,10 +126,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 				.TextTop()
 				.TextCenterVertical()
 				.TextBottom()
-				.TextCenter()
-				.FontSize(8.0)
-				.Bold()
-				.Italic());
+				.TextCenter());
 		}
 
 		class DerivedFromEntry : Entry { }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -119,7 +119,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		public void SupportCustomTextAlignment()
 		{
 			Assert.IsInstanceOf<LeftToRightCustomTextAlignmentControl>(
-				new CustomTextAlignmentControl()
+				new LeftToRightCustomTextAlignmentControl()
 				.TextStart()
 				.TextCenterHorizontal()
 				.TextEnd()
@@ -177,7 +177,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		public void SupportCustomTextAlignment()
 		{
 			Assert.IsInstanceOf<RightToLeftCustomTextAlignmentControl>(
-				new CustomTextAlignmentControl()
+				new RightToLeftCustomTextAlignmentControl()
 				.TextStart()
 				.TextCenterHorizontal()
 				.TextEnd()

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -68,10 +68,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 				.TextTop()
 				.TextCenterVertical()
 				.TextBottom()
-				.TextCenter()
-				.FontSize(8.0)
-				.Bold()
-				.Italic());
+				.TextCenter());
 		}
 
 		class DerivedFromSearchBar : SearchBar { }
@@ -190,10 +187,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 				.TextTop()
 				.TextCenterVertical()
 				.TextBottom()
-				.TextCenter()
-				.FontSize(8.0)
-				.Bold()
-				.Italic());
+				.TextCenter());
 		}
 
 		class DerivedFromEditor : Editor { }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using CommunityToolkit.Maui.Markup.UnitTests.Base;
+﻿using System.Threading.Tasks;
+using CommunityToolkit.Maui.Markup.UnitTests.Base;
+using CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
@@ -39,6 +41,97 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 					l => l.TextCenter(),
 					(TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center),
 					(TextAlignmentElement.VerticalTextAlignmentProperty, TextAlignment.Start, TextAlignment.Center));
+
+		[Test]
+		public void PublicTextAlignmentView()
+		{
+			Assert.IsInstanceOf<PublicTextAlignmentView>(
+				new PublicTextAlignmentView()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter());
+		}
+
+		[Test]
+		public void InternalTextAlignmentView()
+		{
+			Assert.IsInstanceOf<InternalTextAlignmentView>(
+				new InternalTextAlignmentView()
+				.TextStart()
+				.TextCenterHorizontal()
+				.TextEnd()
+				.TextTop()
+				.TextCenterVertical()
+				.TextBottom()
+				.TextCenter());
+		}
+
+		[Test]
+		public void Extensions_For_Generic_Class()
+		{
+			var textAlignmentView = new GenericPicker<
+				ClassConstraintWithInterface,
+				ClassConstraint,
+				StructConstraint,
+				ClassConstraintWithInterface,
+				string,
+				int,
+				bool,
+				ClassConstraintWithInterface?,
+				ClassConstraint[],
+				ClassConstraintWithInterface,
+				RecordClassContstraint,
+				RecordClassContstraint[],
+				RecordStructContstraint>
+			{
+				HorizontalTextAlignment = TextAlignment.Center
+			};
+
+			Assert.AreEqual(TextAlignment.Center, textAlignmentView.HorizontalTextAlignment);
+
+			textAlignmentView.TextEnd();
+
+			Assert.AreEqual(TextAlignment.End, textAlignmentView.HorizontalTextAlignment);
+		}
+
+		[Test]
+		public void GenericPickerShouldUseThePickerExtension()
+		{
+			var genericPicker = new MyGenericPicker<string>();
+
+			Assert.AreEqual(TextAlignment.Start, genericPicker.HorizontalTextAlignment);
+
+			genericPicker.TextEnd();
+
+			Assert.AreEqual(TextAlignment.End, genericPicker.HorizontalTextAlignment);
+		}
+
+		[Test]
+		public void MoreGenericPickerShouldUseThePickerExtension()
+		{
+			var genericPicker = new MoreGenericPicker<string>();
+
+			Assert.AreEqual(TextAlignment.Start, genericPicker.HorizontalTextAlignment);
+
+			genericPicker.TextEnd();
+
+			Assert.AreEqual(TextAlignment.End, genericPicker.HorizontalTextAlignment);
+		}
+
+		[Test]
+		public void BrandNewControlShouldHaveHisOwnExtensionMethod()
+		{
+			var brandNewControl = new BrandNewControl();
+			Assert.AreEqual(TextAlignment.Start, brandNewControl.HorizontalTextAlignment);
+
+			brandNewControl.TextEnd();
+
+			Assert.AreEqual(TextAlignment.End, brandNewControl.HorizontalTextAlignment);
+		}
 
 		[Test]
 		public void SupportDerivedFromBindable()
@@ -143,6 +236,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 namespace CommunityToolkit.Maui.Markup.UnitTests
 {
 	using CommunityToolkit.Maui.Markup.RightToLeft;
+	using CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions;
 
 	[TestFixture]
 	class RightToLeftTextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
@@ -200,14 +294,14 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 
 namespace CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions
 {
-	public class PublicTextStyleView : View, ICustomTextAlignment
+	public class PublicTextAlignmentView : View, ICustomTextAlignment
 	{
 		public TextAlignment HorizontalTextAlignment { get; set; }
 
 		public TextAlignment VerticalTextAlignment { get; set; }
 	}
 
-	class InternalTextStyleView : View, ICustomTextAlignment
+	class InternalTextAlignmentView : View, ICustomTextAlignment
 	{
 		public TextAlignment HorizontalTextAlignment { get; set; }
 

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -285,7 +285,9 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextAlignmentExtensions
 		where TL : class
 		where TM : struct
 	{
+		public TextAlignment HorizontalTextAlignment { get; set; }
 
+		public TextAlignment VerticalTextAlignment { get; set; }
 	}
 
 	class BrandNewControl : View, ITextAlignment

--- a/src/CommunityToolkit.Maui.Markup.sln
+++ b/src/CommunityToolkit.Maui.Markup.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\global.json = ..\global.json
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Maui.Markup.SourceGenerators", "CommunityToolkit.Maui.Markup.SourceGenerators\CommunityToolkit.Maui.Markup.SourceGenerators.csproj", "{C66CEA39-565E-479C-974D-72795D3502CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{480F4FB8-F50A-4349-B5B6-C4D6D9151343}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{480F4FB8-F50A-4349-B5B6-C4D6D9151343}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{480F4FB8-F50A-4349-B5B6-C4D6D9151343}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C66CEA39-565E-479C-974D-72795D3502CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C66CEA39-565E-479C-974D-72795D3502CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C66CEA39-565E-479C-974D-72795D3502CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C66CEA39-565E-479C-974D-72795D3502CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj
+++ b/src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj
@@ -41,6 +41,6 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CommunityToolkit.Maui.Markup.SourceGenerators\CommunityToolkit.Maui.Markup.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<None Include="..\CommunityToolkit.Maui.Markup.SourceGenerators\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Maui.Markup.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
 ### Description of Change ###

This PR updates `TextAlignmentExtensionsGenerator` to support all user-generated types that implement `ITextAlignment`, and adds associated Unit Tests.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #116 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

The implementation of this PR is inspired by [`CommunityToolkit.Maui.SourceGenerators.Generators.TextColorToGenerator`](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs).
 
