### PR TITLE
Remove Duplicated `ContentPage` Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,55 +67,11 @@ For further details on the possible options for the `Size` method refer to the [
 
 ### In-depth example
 
-The following example shows setting the page content to a new `Grid` containing a `Label` and an `Entry`, in C#:
+This example creates a `Grid` object, with child `Label` and `Entry` objects. The `Label` displays text, and the `Entry` data binds to the `RegistrationCode` property of the viewmodel. Each child view is set to appear in a specific row in the `Grid`, and the `Entry` spans all the columns in the `Grid`. In addition, the height of the `Entry` is set, along with its keyboard, colors, the font size of its text, and its `Margin`. 
 
-```csharp
-class SampleContentPage : ContentPage
-{
-    public SampleContentPage()
-    {
-        Grid grid = new Grid
-        {
-            RowDefinitions =
-            {
-                new RowDefinition { Height = new GridLength(36, GridUnitType.Absolute) }
-            },
+C# Markup extensions also allow developers to define names for Columns and Rows (e.g. `Column.Input`) using an `enum`.
 
-            ColumnDefinitions =
-            {
-                new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
-                new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) }
-            }
-        }
-
-        Label label = new Label { Text = "Code: " };
-        grid.Children.Add(label);
-        GridLayout.SetColumn(label, 0);
-        GridLayout.SetRow(label, 0);
-
-        Entry entry = new Entry
-        {
-            Placeholder = "Enter number",
-            Keyboard = Keyboard.Numeric,
-            BackgroundColor = Colors.AliceBlue,
-            TextColor = Colors.Black,
-            FontSize = 15,
-            HeightRequest = 44,
-            Margin = new Thickness(5)
-        };
-        grid.Children.Add(entry);
-        GridLayout.SetColumn(label, 1);
-        GridLayout.SetRow(label, 0);
-        entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModel.RegistrationCode));
-
-        Content = grid;
-    }
-}
-```
-
-This example creates a `Grid` object, with child `Label` and `Entry` objects. The `Label` displays text, and the `Entry` data binds to the `RegistrationCode` property of the viewmodel. Each child view is set to appear in a specific row in the `Grid`, and the `Entry` spans all the columns in the `Grid`. In addition, the height of the `Entry` is set, along with its keyboard, colors, the font size of its text, and its `Margin`. Finally, the `Page.Content` property is set to the `Grid` object.
-
-C# Markup enables this code to be re-written using its fluent API:
+C# Markup enables this to be defined using its fluent API:
 
 ```csharp
 using static CommunityToolkit.Maui.Markup.GridRowsColumns;
@@ -159,9 +115,6 @@ class SampleContentPage : ContentPage
 }
 ```
 
-This example is identical to the previous example, but the C# Markup fluent API simplifies the process of building the UI in C#.
-
-C# Markup extensions also allow developers to use an `enum` to define names for Columns and Rows (e.g. `Column.Input`).
 
 ## Submitting A New Feature
 


### PR DESCRIPTION
This PR removes the duplicate, non-fluent, C# example from the README to match the update to the official docs: https://github.com/MicrosoftDocs/CommunityToolkit/pull/159