### PR TITLE
Remove `BindableObject` Constraint from `.Assign()` and `.Invoke()`

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.UnitTests/BindableObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/BindableObjectExtensionsTests.cs
@@ -475,7 +475,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 					ArgumentNullException.ThrowIfNull(text);
 					ArgumentNullException.ThrowIfNull(repeat);
 
-					return text.Substring(0, text.Length / repeat.Value).Trim('\'');
+					return text[..(text.Length / repeat.Value)].Trim('\'');
 				},
 				2
 			);
@@ -693,20 +693,6 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 		}
 
 		[Test]
-		public void Assign()
-		{
-			var createdLabel = new Label().Assign(out Label assignLabel);
-			Assert.That(ReferenceEquals(createdLabel, assignLabel));
-		}
-
-		[Test]
-		public void Invoke()
-		{
-			var createdLabel = new Label().Invoke(null).Invoke(l => l.Text = nameof(Invoke));
-			Assert.That(createdLabel.Text, Is.EqualTo(nameof(Invoke)));
-		}
-
-		[Test]
 		public void SupportDerivedElements()
 		{
 			Assert.IsInstanceOf<DerivedFromLabel>(
@@ -744,6 +730,7 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 				.Assign(out DerivedFromLabel assignDerivedFromLabel));
 
 			Assert.IsInstanceOf<DerivedFromTextCell>(new DerivedFromTextCell().BindCommand(nameof(viewModel.Command)));
+			Assert.IsInstanceOf<DerivedFromLabel>(assignDerivedFromLabel);
 		}
 
 		[TestCase(AppTheme.Light)]

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
@@ -18,15 +18,25 @@ class ObjectExtensionsTests : BaseMarkupTestFixture
 	[Test]
 	public void AssignString()
 	{
-		var createdString = "Hello World".Assign(out string assignedString);
+		string? testString = null;
+		const string text = "Hello World";
+
+		var createdString = text.Invoke(_ => testString = text).Assign(out string assignedString);
+
+		Assert.NotNull(testString);
+		Assert.AreEqual(text, testString);
+		Assert.AreEqual(text, assignedString);
+		Assert.AreEqual(text, createdString);
 		Assert.That(ReferenceEquals(createdString, assignedString));
 	}
 
 	[Test]
 	public void Invoke()
 	{
-		var createdLabel = new Label().Invoke(l => l.Text = nameof(Invoke));
-		Assert.That(createdLabel.Text, Is.EqualTo(nameof(Invoke)));
+		const string text = nameof(Invoke);
+
+		var createdLabel = new Label().Invoke(l => l.Text = text);
+		Assert.That(createdLabel.Text, Is.EqualTo(text));
 	}
 
 	[Test]

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using CommunityToolkit.Maui.Markup.UnitTests.Base;
+using Microsoft.Maui.Controls;
+using NUnit.Framework;
+
+namespace CommunityToolkit.Maui.Markup.UnitTests;
+
+[TestFixture]
+class ObjectExtensionsTests : BaseMarkupTestFixture
+{
+	[Test]
+	public void Assign()
+	{
+		var createdLabel = new Label().Assign(out Label assignLabel);
+		Assert.That(ReferenceEquals(createdLabel, assignLabel));
+	}
+
+	[Test]
+	public void Invoke()
+	{
+		var createdLabel = new Label().Invoke(l => l.Text = nameof(Invoke));
+		Assert.That(createdLabel.Text, Is.EqualTo(nameof(Invoke)));
+	}
+
+	[Test]
+	public void InvokeNullThrowsArgumentNullException()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new Label().Invoke(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}
+

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
@@ -47,4 +47,3 @@ class ObjectExtensionsTests : BaseMarkupTestFixture
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 }
-

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
@@ -9,10 +9,17 @@ namespace CommunityToolkit.Maui.Markup.UnitTests;
 class ObjectExtensionsTests : BaseMarkupTestFixture
 {
 	[Test]
-	public void Assign()
+	public void AssignLabel()
 	{
-		var createdLabel = new Label().Assign(out Label assignLabel);
-		Assert.That(ReferenceEquals(createdLabel, assignLabel));
+		var createdLabel = new Label().Assign(out Label assignedLabel);
+		Assert.That(ReferenceEquals(createdLabel, assignedLabel));
+	}
+
+	[Test]
+	public void AssignString()
+	{
+		var createdString = "Hello World".Assign(out string assignedString);
+		Assert.That(ReferenceEquals(createdString, assignedString));
 	}
 
 	[Test]

--- a/src/CommunityToolkit.Maui.Markup/BindableObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/BindableObjectExtensions.cs
@@ -27,6 +27,7 @@ public static class BindableObjectExtensions
 				TargetNullValue = targetNullValue,
 				FallbackValue = fallbackValue
 			});
+
 		return bindable;
 	}
 
@@ -51,6 +52,7 @@ public static class BindableObjectExtensions
 				TargetNullValue = targetNullValue,
 				FallbackValue = fallbackValue
 			});
+
 		return bindable;
 	}
 
@@ -76,6 +78,7 @@ public static class BindableObjectExtensions
 				TargetNullValue = targetNullValue,
 				FallbackValue = fallbackValue
 			});
+
 		return bindable;
 	}
 
@@ -111,6 +114,7 @@ public static class BindableObjectExtensions
 		TDest? fallbackValue = default) where TBindable : BindableObject
 	{
 		var converter = new FuncConverter<TSource, TDest, object>(convert, convertBack);
+
 		bindable.Bind(
 			DefaultBindableProperties.GetDefaultProperty<TBindable>(),
 			path, mode, converter, null, stringFormat, source, targetNullValue, fallbackValue);
@@ -161,34 +165,6 @@ public static class BindableObjectExtensions
 			bindable.SetBinding(parameterProperty, new Binding(path: parameterPath, source: parameterSource));
 		}
 
-		return bindable;
-	}
-
-	/// <summary>
-	/// Assign TBindable to a variable
-	/// </summary>
-	/// <typeparam name="TBindable"></typeparam>
-	/// <typeparam name="TVariable"></typeparam>
-	/// <param name="bindable"></param>
-	/// <param name="variable"></param>
-	/// <returns>TBindable</returns>
-	public static TBindable Assign<TBindable, TVariable>(this TBindable bindable, out TVariable variable)
-		where TBindable : BindableObject, TVariable
-	{
-		variable = bindable;
-		return bindable;
-	}
-
-	/// <summary>
-	/// Perform an action on a Bindable Object
-	/// </summary>
-	/// <typeparam name="TBindable"></typeparam>
-	/// <param name="bindable"></param>
-	/// <param name="action"></param>
-	/// <returns>TBindable</returns>
-	public static TBindable Invoke<TBindable>(this TBindable bindable, Action<TBindable>? action) where TBindable : BindableObject
-	{
-		action?.Invoke(bindable);
 		return bindable;
 	}
 

--- a/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
@@ -35,4 +35,3 @@ public static class ObjectExtensions
 		return assignable;
 	}
 }
-

--- a/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
@@ -6,32 +6,33 @@
 public static class ObjectExtensions
 {
 	/// <summary>
-	/// Assign TBindable to a variable
+	/// Assign <typeparam name="TAssignable"/> to a variable
 	/// </summary>
-	/// <typeparam name="TBindable"></typeparam>
+	/// <typeparam name="TAssignable"></typeparam>
 	/// <typeparam name="TVariable"></typeparam>
-	/// <param name="bindable"></param>
+	/// <param name="assignable"></param>
 	/// <param name="variable"></param>
 	/// <returns>TBindable</returns>
-	public static TBindable Assign<TBindable, TVariable>(this TBindable bindable, out TVariable variable)
-		where TBindable : TVariable
+	public static TAssignable Assign<TAssignable, TVariable>(this TAssignable assignable, out TVariable variable)
+		where TAssignable : TVariable
 	{
-		variable = bindable;
-		return bindable;
+		variable = assignable;
+		return assignable;
 	}
+
 	/// <summary>
-	/// Perform an action on a Bindable Object
+	/// Perform an action on <typeparam name="TAssignable"/>
 	/// </summary>
-	/// <typeparam name="TBindable"></typeparam>
-	/// <param name="bindable"></param>
+	/// <typeparam name="TAssignable"></typeparam>
+	/// <param name="assignable"></param>
 	/// <param name="action"></param>
 	/// <returns>TBindable</returns>
-	public static TBindable Invoke<TBindable>(this TBindable bindable, Action<TBindable> action)
+	public static TAssignable Invoke<TAssignable>(this TAssignable assignable, Action<TAssignable> action)
 	{
 		ArgumentNullException.ThrowIfNull(action);
 
-		action.Invoke(bindable);
-		return bindable;
+		action(assignable);
+		return assignable;
 	}
 }
 

--- a/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
@@ -1,0 +1,37 @@
+﻿namespace CommunityToolkit.Maui.Markup;
+
+/// <summary>
+/// Extension Methods for Unconstrained Objects
+/// </summary>
+public static class ObjectExtensions
+{
+	/// <summary>
+	/// Assign TBindable to a variable
+	/// </summary>
+	/// <typeparam name="TBindable"></typeparam>
+	/// <typeparam name="TVariable"></typeparam>
+	/// <param name="bindable"></param>
+	/// <param name="variable"></param>
+	/// <returns>TBindable</returns>
+	public static TBindable Assign<TBindable, TVariable>(this TBindable bindable, out TVariable variable)
+		where TBindable : BindableObject, TVariable
+	{
+		variable = bindable;
+		return bindable;
+	}
+	/// <summary>
+	/// Perform an action on a Bindable Object
+	/// </summary>
+	/// <typeparam name="TBindable"></typeparam>
+	/// <param name="bindable"></param>
+	/// <param name="action"></param>
+	/// <returns>TBindable</returns>
+	public static TBindable Invoke<TBindable>(this TBindable bindable, Action<TBindable> action)
+	{
+		ArgumentNullException.ThrowIfNull(action);
+
+		action.Invoke(bindable);
+		return bindable;
+	}
+}
+

--- a/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
@@ -14,7 +14,7 @@ public static class ObjectExtensions
 	/// <param name="variable"></param>
 	/// <returns>TBindable</returns>
 	public static TBindable Assign<TBindable, TVariable>(this TBindable bindable, out TVariable variable)
-		where TBindable : BindableObject, TVariable
+		where TBindable : TVariable
 	{
 		variable = bindable;
 		return bindable;


### PR DESCRIPTION
 ### Description of Change ###

This PR  removes the `BindableObject` constraint (`where T : BindableObject`) from `.Assign()` and `.Invoke()` extension methods.

### Before
```cs
public static TBindable Assign<TBindable, TVariable>(this TBindable bindable, out TVariable variable) 
  where TBindable : BindableObject, TVariable;

public static TBindable Invoke<TBindable>(this TBindable bindable, Action<TBindable> action) 
  where TBindable : BindableObject;
```

### After
```cs
public static TAssignable Assign<TAssignable, TVariable>(this TAssignable assignable, out TVariable variable) 
  where TAssignable : TVariable;

public static TAssignable Invoke<TAssignable>(this TAssignable assignable, Action<TAssignable> action);
  // no constraint
```

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui.Markup/issues/130

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated
