### PR TITLE
Fix TextAlignment Tests

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.UnitTests/Base/BaseMarkupTestFixture.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/Base/BaseMarkupTestFixture.cs
@@ -69,7 +69,7 @@ abstract class BaseMarkupTestFixture : BaseTestFixture
 		foreach (var (property, expectedValue) in propertyChanges)
 		{
 			bindable.SetValue(property, property.DefaultValue);
-			Assume.That(bindable.GetPropertyIfSet(property, expectedValue), Is.Not.EqualTo(expectedValue));
+			Assert.That(bindable.GetPropertyIfSet(property, expectedValue), Is.Not.EqualTo(expectedValue));
 		}
 
 		modify(bindable);

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TextAlignmentExtensionsTests.cs
@@ -181,14 +181,24 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 	[TestFixture]
 	class LeftToRightTextAlignmentExtensionsTests : BaseMarkupTestFixture<Picker>
 	{
-
 		[Test]
 		public void TextLeft()
-			=> TestPropertiesSet(l => l.TextLeft(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start));
+		{
+			Bindable.TextEnd();
+			Assert.AreEqual(TextAlignment.End, Bindable.HorizontalTextAlignment);
+
+			Bindable.TextLeft();
+			Assert.AreEqual(TextAlignment.Start, Bindable.HorizontalTextAlignment);
+		}
 
 		[Test]
 		public void TextRight()
-			=> TestPropertiesSet(l => l.TextRight(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End));
+		{
+			Assert.AreEqual(TextAlignment.Start, Bindable.HorizontalTextAlignment);
+
+			Bindable.TextRight();
+			Assert.AreEqual(TextAlignment.End, Bindable.HorizontalTextAlignment);
+		}
 
 		[Test]
 		public void SupportDerivedFromBindable()
@@ -241,12 +251,23 @@ namespace CommunityToolkit.Maui.Markup.UnitTests
 	{
 
 		[Test]
-		public void TextLeft()
-			=> TestPropertiesSet(l => l.TextLeft(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.End));
+		public void TextRight()
+		{
+			Bindable.TextEnd();
+			Assert.AreEqual(TextAlignment.End, Bindable.HorizontalTextAlignment);
+
+			Bindable.TextRight();
+			Assert.AreEqual(TextAlignment.Start, Bindable.HorizontalTextAlignment);
+		}
 
 		[Test]
-		public void TextRight()
-			=> TestPropertiesSet(l => l.TextRight(), (TextAlignmentElement.HorizontalTextAlignmentProperty, TextAlignment.Start));
+		public void TextLeft()
+		{
+			Assert.AreEqual(TextAlignment.Start, Bindable.HorizontalTextAlignment);
+
+			Bindable.TextLeft();
+			Assert.AreEqual(TextAlignment.End, Bindable.HorizontalTextAlignment);
+		}
 
 		[Test]
 		public void SupportDerivedFromBindable()


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes tests that were being skipped instead of failing.

The [logs from the latest CI Build](https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=82056&view=logs&j=c44e3ce6-80b8-5090-9435-9627042472dc&t=dc770622-70f0-5084-e949-6d62de2aa47d&l=26) show that two tests were being skipped:
- `TextLeft`
- `TextRight`

The CI Build was still passing because the tests were using `Assume.That` which will skip the test when a failure occurs. 

This PR replaces `Assume.That` with `Assert.That`, and updates the TextAlignment tests to perform the tests without utilizing `TestPropertiesSet()` which requires the changing BindableProperty to be different from its default value.

This PR fixes 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has tests (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 
### Additional Info

The good news is that there is not a bug in `CommunityToolit.Maui.Markup`, rather the bug was isolated to `CommunityToolit.Maui.Markup.UnitTests`.