### PR TITLE
Update `ObjectExtensionsTests` to Include Derived Types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,9 @@
     <!--CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name -->
     <!--CS1573: Parameter has no matching param tag in the XML comment -->
     <!--CS1574: XML comment has cref attribute that could not be resolved-->
+    <!--CS1710: XML comment has a duplicate typeparam tag-->
     <!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
-    <WarningsAsErrors>nullable,CS1570,CS1571,CS1572,CS1573,CS1574,CS1734</WarningsAsErrors>
+    <WarningsAsErrors>nullable,CS1570,CS1571,CS1572,CS1573,CS1574,CS1710,CS1734</WarningsAsErrors>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
@@ -16,6 +16,13 @@ class ObjectExtensionsTests : BaseMarkupTestFixture
 	}
 
 	[Test]
+	public void AssignCustomLabel()
+	{
+		var createdLabel = new CustomLabel().Assign(out Label assignedLabel);
+		Assert.That(ReferenceEquals(createdLabel, assignedLabel));
+	}
+
+	[Test]
 	public void AssignString()
 	{
 		string? testString = null;
@@ -40,10 +47,29 @@ class ObjectExtensionsTests : BaseMarkupTestFixture
 	}
 
 	[Test]
+	public void InvokeCustomEntry()
+	{
+		const string text = nameof(Invoke);
+
+		var createdLabel = new CustomEntry().Invoke(l => l.Text = text);
+		Assert.That(createdLabel.Text, Is.EqualTo(text));
+	}
+
+	[Test]
 	public void InvokeNullThrowsArgumentNullException()
 	{
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		Assert.Throws<ArgumentNullException>(() => new Label().Invoke(null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	class CustomLabel : Label
+	{
+
+	}
+
+	class CustomEntry : Entry
+	{
+
 	}
 }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/ObjectExtensionsTests.cs
@@ -18,8 +18,9 @@ class ObjectExtensionsTests : BaseMarkupTestFixture
 	[Test]
 	public void AssignCustomLabel()
 	{
-		var createdLabel = new CustomLabel().Assign(out Label assignedLabel);
+		var createdLabel = new CustomLabel().Assign(out Label assignedLabel).Assign(out CustomLabel assignedCustomLabel);
 		Assert.That(ReferenceEquals(createdLabel, assignedLabel));
+		Assert.That(ReferenceEquals(assignedCustomLabel, assignedLabel));
 	}
 
 	[Test]

--- a/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/ObjectExtensions.cs
@@ -6,7 +6,7 @@
 public static class ObjectExtensions
 {
 	/// <summary>
-	/// Assign <typeparam name="TAssignable"/> to a variable
+	/// Assign <typeparamref name="TAssignable"/> to a variable
 	/// </summary>
 	/// <typeparam name="TAssignable"></typeparam>
 	/// <typeparam name="TVariable"></typeparam>
@@ -21,7 +21,7 @@ public static class ObjectExtensions
 	}
 
 	/// <summary>
-	/// Perform an action on <typeparam name="TAssignable"/>
+	/// Perform an action on <typeparamref name="TAssignable"/>
 	/// </summary>
 	/// <typeparam name="TAssignable"></typeparam>
 	/// <param name="assignable"></param>


### PR DESCRIPTION
 ### Description of Change ###

This PR adds Unit Tests to `ObjectExtensionsTests` to ensure derived types are supported by `.Assign()` and `.Invoke()`.



 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #135 
   - Technically, it doesn't "fix" the Issues, but rather confirms that we cannot reproduce the Issue

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This PR does not change any code in the `CommunityToolkit.Maui.Markup` library.

This PR technically, it doesn't "fix" #135. Rather, it confirms that we cannot reproduce #135.

This PR also adds `<WarningsAsErrors>CS1710</WarningsAsErrors>` to avoid duplicate XML Comments
