### PR TITLE
Add Tizen TFM to Sample

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,4 +19,8 @@
   <ItemGroup>
     <InternalsVisibleTo Include="CommunityToolkit.Maui.Markup.UnitTests" />
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' and $([MSBuild]::IsOSPlatform('windows')) == 'true'">
+    <IncludeTizenTargetFrameworks>true</IncludeTizenTargetFrameworks>
+  </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,11 @@ jobs:
               dotnet --info
               dotnet workload install maui
 
+      - pwsh: |
+          Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
+          .\workload-install.ps1
+        displayName: Install Tizen Workload
+
       # if this is a tagged build, then update the version number
       - powershell: |
           $buildSourceBranch = "$(Build.SourceBranch)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,6 +195,11 @@ jobs:
       - powershell: dotnet workload install maui
         displayName: Install Latest .NET MAUI Workload
 
+      - pwsh: |
+          Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
+          .\workload-install.ps1
+      displayName: Install Tizen Workload
+
       - task: Bash@3
         displayName: 'Verify Formatting'
         env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,7 @@ jobs:
       - pwsh: |
           Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
           .\workload-install.ps1
-      displayName: Install Tizen Workload
+        displayName: Install Tizen Workload
 
       - task: Bash@3
         displayName: 'Verify Formatting'

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);net7.0-tizen</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>CommunityToolkit.Maui.Markup.Sample</RootNamespace>
     <UseMaui>true</UseMaui>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Tizen/Main.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Tizen/Main.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace CommunityToolkit.Maui.Markup.Sample;
+
+class Program : MauiApplication
+{
+	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+	static void Main(string[] args)
+	{
+		var app = new Program();
+		app.Run(args);
+	}
+}

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Tizen/tizen-manifest.xml
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Platforms/Tizen/tizen-manifest.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest package="maui-application-id-placeholder" version="0.0.0" api-version="7" xmlns="http://tizen.org/ns/packages">
+    <profile name="common" />
+    <ui-application appid="maui-application-id-placeholder" exec="CommunityToolkit.Maui.Markup.Sample.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+        <label>maui-application-title-placeholder</label>
+        <icon>maui-appicon-placeholder</icon>
+        <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />
+        <splash-screens />
+    </ui-application>
+    <shortcut-list />
+    <privileges>
+        <privilege>http://tizen.org/privilege/internet</privilege>
+        <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
+    </privileges>
+    <dependencies />
+    <provides-appdefined-privileges />
+</manifest>


### PR DESCRIPTION
 ### Description of Change ###

This PR adds Tizen support on Maui Markup Sample!
Tizen Workload is not included in the default MAUI Workloads, so it will break unless you install the Tizen Workload.
Therefore, [`TF_BUILD`](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml) condition is set for adding `net7.0-tizen` as the TargetFrameworks so it is only included in the CI environment where Tizen workload environment is prepared.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #137 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
<img src="https://user-images.githubusercontent.com/14328614/201608338-9ee88268-e91f-4c97-a275-b25c66283234.gif" width="300" />

 
