### PR TITLE
Make All Generated Classes `internal`

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/SourceGenerators/TextAlignmentExtensionsGenerator.cs
@@ -114,7 +114,7 @@ namespace CommunityToolkit.Maui.Markup
 	/// <summary>
 	/// Extension Methods for <see cref=""ITextAlignment""/>
 	/// </summary>
-	" + textAlignmentClass.ClassAcessModifier + " static partial class TextAlignmentExtensions_" + textAlignmentClass.ClassName + @"
+	static partial class TextAlignmentExtensions_" + textAlignmentClass.ClassName + @"
 	{
 		/// <summary>
 		/// <see cref=""ITextAlignment.HorizontalTextAlignment""/> = <see cref=""TextAlignment.Start""/>


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Markup Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Markup Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI Markup core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui.markup/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This PR changes generated classes, i.e. code generated by `TextAlignmentExtensionsGenerator`, from `public` to `internal`.

The bug in #158 is caused by two matching public classes being generated in both the .NET MAUI library (eg `net7.0-ios`) and the referenced class library (e.g. `net7.0`).

```
📦MyMauiSolution
 ┣ 📂MyMauiApp
    - <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 ┗ 📂MyLibrary
    - <TargetFramework>net7.0</TargetFramework>
```

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #158 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This aligns with a similar discussion on the `CommunityToolkit.Maui` repo: https://github.com/CommunityToolkit/Maui/discussions/756#discussioncomment-4125731
 
