### PR TITLE
Add Support for `IValueConverter` in Typed Bindings Extensions

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -42,7 +42,7 @@ sealed class SettingsPage : BaseContentPage<SettingsViewModel>
 					.Bind(Entry.TextProperty, static (SettingsViewModel vm) => vm.NumberOfTopStoriesToFetch, static (SettingsViewModel vm, int text) => vm.NumberOfTopStoriesToFetch = text),
 
 				new Label()
-					.Bind<Label, int, int, string>(
+					.Bind(
 						Label.TextProperty,
 						binding1: new Binding { Source = SettingsService.MinimumStoriesToFetch },
 						binding2: new Binding { Source = SettingsService.MaximumStoriesToFetch },

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/BindingHelpers.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/BindingHelpers.cs
@@ -60,15 +60,23 @@ static class BindingHelpers
 		TBindingContext expectedSource,
 		Func<TSource?, TDest>? expectedConverter = null,
 		string? expectedFormat = null) where TBindable : BindableObject
-		=> AssertTypedBindingExists<TBindable, TBindingContext, TSource, object?, TDest>(
-			bindable, targetProperty, expectedBindingMode, expectedSource, expectedConverter, expectedStringFormat: expectedFormat);
+	{
+		var funcConverter = expectedConverter switch
+		{
+			null => null,
+			_ => new FuncConverter<TSource, TDest, object>(expectedConverter, null)
+		};
+
+		AssertTypedBindingExists<TBindable, TBindingContext, TSource, object?, TDest>(
+			bindable, targetProperty, expectedBindingMode, expectedSource, funcConverter, expectedStringFormat: expectedFormat);
+	}
 
 	internal static void AssertTypedBindingExists<TBindable, TBindingContext, TSource, TParam, TDest>(
 		TBindable bindable,
 		BindableProperty targetProperty,
 		BindingMode expectedBindingMode,
 		TBindingContext expectedSource,
-		Func<TSource?, TDest>? expectedConverter = null,
+		IValueConverter? expectedConverter = null,
 		string? expectedStringFormat = null,
 		TDest? expectedTargetNullValue = default,
 		TDest? expectedFallbackValue = default,
@@ -79,13 +87,7 @@ static class BindingHelpers
 
 		Assert.That(binding.Mode, Is.EqualTo(expectedBindingMode));
 
-		var funcConverter = expectedConverter switch
-		{
-			null => null,
-			_ => new FuncConverter<TSource, TDest, TParam>(expectedConverter, null)
-		};
-
-		Assert.That(binding.Converter?.ToString(), Is.EqualTo(funcConverter?.ToString()));
+		Assert.That(binding.Converter?.ToString(), Is.EqualTo(expectedConverter?.ToString()));
 
 		Assert.That(binding.ConverterParameter, Is.EqualTo(expectedConverterParameter));
 

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/CommunityToolkit.Maui.Markup.UnitTests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 ### Description of Change ###

This PR adds support for `IValueConverter` with Typed Bindings extensions

 ### Linked Issues ###
 - Fixes https://github.com/CommunityToolkit/Maui.Markup/issues/179

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/226


 ### Additional information ###

Allows the use of `IValueConverter` with the new Typed Bindings extensions, such as [`CommunityToolkit.Maui.Converters.ColorToHexRgbStringConverter` in the .NET MAUI Community Toolkit](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/maui/converters/color-to-hex-rgba-string-converter):

```cs
new Label().Bind<Label, ViewModel, Color, string>(Label.TextProperty,
				static (ViewModel viewModel) => viewModel.TextColor,
				converter: new ColorToHexRgbStringConverter());
```
 
