### PR TITLE
Add `BindCommand` Support for Typed Bindings Extensions

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsDetailPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsDetailPage.cs
@@ -24,7 +24,7 @@ sealed class NewsDetailPage : BaseContentPage<NewsDetailViewModel>
 					.Font(size: 20, family: "FontAwesome")
 					.Basis(50)
 					.Style(AppStyles.ButtonStyle)
-					.Bind(Button.CommandProperty, static (NewsDetailViewModel vm) => vm.OpenBrowserCommand, mode: BindingMode.OneWay)
+					.BindCommand(static (NewsDetailViewModel vm) => vm.OpenBrowserCommand, mode: BindingMode.OneWay)
 					.SemanticHint("Launches the news article in the devices browser."),
 
 				new Label()

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/NewsPage.cs
@@ -28,7 +28,7 @@ sealed class NewsPage : BaseContentPage<NewsViewModel>
 			 .AutomationId("NewsCollectionView")
 
 		}.Bind(RefreshView.IsRefreshingProperty, static (NewsViewModel vm) => vm.IsListRefreshing, static (NewsViewModel vm, bool isRefreshing) => vm.IsListRefreshing = isRefreshing)
-		 .Bind(RefreshView.CommandProperty, static (NewsViewModel vm) => vm.PullToRefreshCommand)
+		 .BindCommand(static (NewsViewModel vm) => vm.PullToRefreshCommand, mode: BindingMode.OneTime)
 		 .AppThemeColorBinding(RefreshView.RefreshColorProperty, Colors.Black, Colors.LightGray)
 		 .Assign(out refreshView);
 	}

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/BindingHelpers.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/BindingHelpers.cs
@@ -44,13 +44,13 @@ static class BindingHelpers
 			bindable, targetProperty, path, mode, assertConverterInstanceIsAnyNotNull, converter, null,
 			stringFormat, source, targetNullValue, fallbackValue, assertConvert);
 
-	internal static void AssertTypedBindingExists<TBindable, TBindingContext, TSource>(
+	internal static void AssertTypedBindingExists<TBindable, TBindingContext>(
 		TBindable bindable,
 		BindableProperty targetProperty,
 		BindingMode expectedBindingMode,
 		TBindingContext expectedSource,
 		string? expectedFormat = null) where TBindable : BindableObject
-		=> AssertTypedBindingExists<TBindable, TBindingContext, TSource, object?, object?>(
+		=> AssertTypedBindingExists<TBindable, TBindingContext, object?, object?, object?>(
 			bindable, targetProperty, expectedBindingMode, expectedSource, expectedStringFormat: expectedFormat);
 
 	internal static void AssertTypedBindingExists<TBindable, TBindingContext, TSource, TDest>(

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TypedBindingExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TypedBindingExtensionsTests.cs
@@ -59,7 +59,7 @@ class TypedBindingExtensionsTests : BaseMarkupTestFixture
 
 		textCell.BindCommand(static (ViewModel vm) => vm.Command);
 
-		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandProperty, BindingMode.OneTime, viewModel);
+		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandProperty, BindingMode.Default, viewModel);
 		Assert.That(BindingHelpers.GetBinding(textCell, TextCell.CommandParameterProperty), Is.Null);
 	}
 

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/TypedBindingExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/TypedBindingExtensionsTests.cs
@@ -57,9 +57,9 @@ class TypedBindingExtensionsTests : BaseMarkupTestFixture
 			BindingContext = viewModel
 		};
 
-		textCell.BindCommand((ViewModel vm) => vm.Command);
+		textCell.BindCommand(static (ViewModel vm) => vm.Command);
 
-		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandProperty, BindingMode.Default, viewModel);
+		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandProperty, BindingMode.OneTime, viewModel);
 		Assert.That(BindingHelpers.GetBinding(textCell, TextCell.CommandParameterProperty), Is.Null);
 	}
 
@@ -73,10 +73,14 @@ class TypedBindingExtensionsTests : BaseMarkupTestFixture
 			BindingContext = viewModel
 		};
 
-		textCell.BindCommand((ViewModel vm) => vm.Command, parameterGetter: (ViewModel vm) => vm.Id);
+		textCell.BindCommand(
+			static (ViewModel vm) => vm.Command,
+			commandBindingMode: BindingMode.OneTime,
+			parameterGetter: static (ViewModel vm) => vm.Id,
+			parameterBindingMode: BindingMode.OneWay);
 
-		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandProperty, BindingMode.Default, viewModel);
-		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandParameterProperty, BindingMode.Default, viewModel);
+		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandProperty, BindingMode.OneTime, viewModel);
+		BindingHelpers.AssertTypedBindingExists(textCell, TextCell.CommandParameterProperty, BindingMode.OneWay, viewModel);
 
 		Assert.AreEqual(textCell.Command, viewModel.Command);
 		Assert.AreEqual(textCell.CommandParameter, viewModel.Id);

--- a/src/CommunityToolkit.Maui.Markup/GesturesExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/GesturesExtensions.cs
@@ -46,7 +46,7 @@ public static class GesturesExtensions
 																		object? commandSource = null,
 																		string? parameterPath = null,
 																		object? parameterSource = null,
-																		Microsoft.Maui.SwipeDirection? direction = null,
+																		SwipeDirection? direction = null,
 																		uint? threshold = null) where TGestureElement : IGestureRecognizers
 	{
 		var swipeGesture = gestureElement.BindGesture<TGestureElement, SwipeGestureRecognizer>(commandPath, commandSource, parameterPath, parameterSource);
@@ -174,7 +174,7 @@ public static class GesturesExtensions
 	/// <returns><paramref name="gestureElement"/></returns>
 	public static TGestureElement SwipeGesture<TGestureElement>(this TGestureElement gestureElement,
 																EventHandler<SwipedEventArgs>? onSwiped = null,
-																Microsoft.Maui.SwipeDirection? direction = null,
+																SwipeDirection? direction = null,
 																uint? threshold = null) where TGestureElement : IGestureRecognizers
 	{
 		var gestureRecognizer = new SwipeGestureRecognizer();

--- a/src/CommunityToolkit.Maui.Markup/TypedBindingExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/TypedBindingExtensions.cs
@@ -14,13 +14,14 @@ public static class TypedBindingExtensions
 		this TBindable bindable,
 		Expression<Func<TCommandBindingContext, ICommand>> getter,
 		Action<TCommandBindingContext, ICommand>? setter = null,
+		BindingMode mode = BindingMode.Default,
 		TCommandBindingContext? source = default) where TBindable : BindableObject
 	{
 		return BindCommand<TBindable, TCommandBindingContext, object?, object?>(
 			bindable,
 			getter,
 			setter,
-			source);
+			mode);
 	}
 
 	/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command and CommandParameter properties </summary>
@@ -29,6 +30,7 @@ public static class TypedBindingExtensions
 		Func<TCommandBindingContext, ICommand> getter,
 		(Func<TCommandBindingContext, object?>, string)[] handlers,
 		Action<TCommandBindingContext, ICommand>? setter = null,
+		BindingMode mode = BindingMode.Default,
 		TCommandBindingContext? source = default) where TBindable : BindableObject
 	{
 		return BindCommand<TBindable, TCommandBindingContext, object?, object?>(
@@ -36,7 +38,8 @@ public static class TypedBindingExtensions
 			getter,
 			handlers,
 			setter,
-			source);
+			source,
+			mode);
 	}
 
 	/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command and CommandParameter properties </summary>
@@ -45,9 +48,11 @@ public static class TypedBindingExtensions
 		Expression<Func<TCommandBindingContext, ICommand>> getter,
 		Action<TCommandBindingContext, ICommand>? setter = null,
 		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
 		Expression<Func<TParameterBindingContext, TParameterSource>>? parameterGetter = null,
 		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
-		TParameterBindingContext? parameterSource = default) where TBindable : BindableObject
+		TParameterBindingContext? parameterSource = default,
+		BindingMode parameterBindingMode = BindingMode.Default) where TBindable : BindableObject
 	{
 		(var commandProperty, var parameterProperty) = DefaultBindableProperties.GetCommandAndCommandParameterProperty<TBindable>();
 
@@ -55,7 +60,7 @@ public static class TypedBindingExtensions
 			commandProperty,
 			getter,
 			setter,
-			BindingMode.Default,
+			commandBindingMode,
 			source: source);
 
 		if (parameterGetter is not null)
@@ -65,7 +70,7 @@ public static class TypedBindingExtensions
 				parameterProperty,
 				parameterGetter,
 				parameterSetter,
-				BindingMode.Default,
+				parameterBindingMode,
 				source: parameterSource);
 		}
 
@@ -79,10 +84,12 @@ public static class TypedBindingExtensions
 		(Func<TCommandBindingContext, object?>, string)[] handlers,
 		Action<TCommandBindingContext, ICommand>? setter = null,
 		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
 		Func<TParameterBindingContext, TParameterSource>? parameterGetter = null,
 		(Func<TParameterBindingContext, object?>, string)[]? parameterHandlers = null,
 		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
-		TParameterBindingContext? parameterSource = default) where TBindable : BindableObject
+		TParameterBindingContext? parameterSource = default,
+		BindingMode parameterBindingMode = BindingMode.Default) where TBindable : BindableObject
 	{
 		(var commandProperty, var parameterProperty) = DefaultBindableProperties.GetCommandAndCommandParameterProperty<TBindable>();
 
@@ -91,7 +98,7 @@ public static class TypedBindingExtensions
 			getter,
 			handlers,
 			setter,
-			BindingMode.Default,
+			commandBindingMode,
 			source: source);
 
 		if (parameterGetter is not null)
@@ -104,7 +111,7 @@ public static class TypedBindingExtensions
 				parameterGetter,
 				parameterHandlers,
 				parameterSetter,
-				BindingMode.Default,
+				parameterBindingMode,
 				source: parameterSource);
 		}
 

--- a/src/CommunityToolkit.Maui.Markup/TypedBindingsExtensions.Handlers.cs
+++ b/src/CommunityToolkit.Maui.Markup/TypedBindingsExtensions.Handlers.cs
@@ -161,4 +161,3 @@ public static partial class TypedBindingExtensions
 		return bindable;
 	}
 }
-

--- a/src/CommunityToolkit.Maui.Markup/TypedBindingsExtensions.Handlers.cs
+++ b/src/CommunityToolkit.Maui.Markup/TypedBindingsExtensions.Handlers.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Markup;
 /// </summary>
 public static partial class TypedBindingExtensions
 {
-	/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command and CommandParameter properties </summary>
+	/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command properties </summary>
 	public static TBindable BindCommand<TBindable, TCommandBindingContext>(
 		this TBindable bindable,
 		Func<TCommandBindingContext, ICommand> getter,

--- a/src/CommunityToolkit.Maui.Markup/TypedBindingsExtensions.Handlers.cs
+++ b/src/CommunityToolkit.Maui.Markup/TypedBindingsExtensions.Handlers.cs
@@ -160,4 +160,33 @@ public static partial class TypedBindingExtensions
 
 		return bindable;
 	}
+
+	/// <summary>Bind to a specified property with inline conversion and conversion parameter</summary>
+	public static TBindable Bind<TBindable, TBindingContext, TSource, TParam, TDest>(
+		this TBindable bindable,
+		BindableProperty targetProperty,
+		Func<TBindingContext, TSource> getter,
+		(Func<TBindingContext, object?>, string)[] handlers,
+		Action<TBindingContext, TSource>? setter = null,
+		BindingMode mode = BindingMode.Default,
+		IValueConverter? converter = null,
+		TParam? converterParameter = default,
+		string? stringFormat = null,
+		TBindingContext? source = default,
+		TDest? targetNullValue = default,
+		TDest? fallbackValue = default) where TBindable : BindableObject
+	{
+		bindable.SetBinding(targetProperty, new TypedBinding<TBindingContext, TSource>(bindingContext => (getter(bindingContext), true), setter, handlers.Select(x => x.ToTuple()).ToArray())
+		{
+			Mode = mode,
+			Converter = converter,
+			ConverterParameter = converterParameter,
+			StringFormat = stringFormat,
+			Source = source,
+			TargetNullValue = targetNullValue,
+			FallbackValue = fallbackValue
+		});
+
+		return bindable;
+	}
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR adds the following APIs which enables users to use `.BindCommand()` with Typed Bindings extensions:

```cs
/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command properties </summary>
public static TBindable BindCommand<TBindable, TCommandBindingContext>(
		this TBindable bindable,
		Expression<Func<TCommandBindingContext, ICommand>> getter,
		Action<TCommandBindingContext, ICommand>? setter = null,
		BindingMode mode = BindingMode.Default,
		TCommandBindingContext? source = default) where TBindable : BindableObject;

/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command properties </summary>
public static TBindable BindCommand<TBindable, TCommandBindingContext>(
		this TBindable bindable,
		Func<TCommandBindingContext, ICommand> getter,
		(Func<TCommandBindingContext, object?>, string)[] handlers,
		Action<TCommandBindingContext, ICommand>? setter = null,
		BindingMode mode = BindingMode.Default,
		TCommandBindingContext? source = default) where TBindable : BindableObject;

/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command and CommandParameter properties </summary>
public static TBindable BindCommand<TBindable, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
		this TBindable bindable,
		Expression<Func<TCommandBindingContext, ICommand>> getter,
		Action<TCommandBindingContext, ICommand>? setter = null,
		TCommandBindingContext? source = default,
		BindingMode commandBindingMode = BindingMode.Default,
		Expression<Func<TParameterBindingContext, TParameterSource>>? parameterGetter = null,
		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
		BindingMode parameterBindingMode = BindingMode.Default,
		TParameterBindingContext? parameterSource = default) where TBindable : BindableObject;

	/// <summary>Bind to the <typeparamref name="TBindable"/>'s default Command and CommandParameter properties </summary>
public static TBindable BindCommand<TBindable, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
		this TBindable bindable,
		Func<TCommandBindingContext, ICommand> getter,
		(Func<TCommandBindingContext, object?>, string)[] handlers,
		Action<TCommandBindingContext, ICommand>? setter = null,
		TCommandBindingContext? source = default,
		BindingMode commandBindingMode = BindingMode.Default,
		Func<TParameterBindingContext, TParameterSource>? parameterGetter = null,
		(Func<TParameterBindingContext, object?>, string)[]? parameterHandlers = null,
		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
		TParameterBindingContext? parameterSource = default,
		BindingMode parameterBindingMode = BindingMode.Default) where TBindable : BindableObject;
```

 ### Linked Issues ###

 - Fixes #181 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: 

 ### Additional information ###

This PR allows Typed Bindings to be used with `.BindCommand()`

```cs
new Button().BindCommand(static (ViewModel vm) => vm.Command, mode: BindingMode.OneTime);
```

Because `TypedBindingExtensions.cs` was growing in size (300+ LOC) and becoming difficult to manage, I created `TypedBindingExtensions.Handlers.cs` that contains all of the Typed Binding extension methods that require a handler parameter for nested bindings (e.g. `(Func<TCommandBindingContext, object?>, string)[] handlers`)