### PR TITLE
[Housekeeping] Enable `AccelerateBuildsInVisualStudio`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <!-- WarningsAsErrors
     CS0419: Ambiguous reference in cref attribute 
     CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 


### PR DESCRIPTION
 ### Description of Change ###

 This PR enables `AccelerateBuildsInVisualStudio`, recently introduced in Visual Studio v17.5:
https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md

> The feature was added in 17.5 and is currently opt-in. It applies to SDK-style .NET projects only. It is simple to try, and in most cases will improve build times. Larger solutions will see greater gains.
>
>
> Visual Studio uses MSBuild to build .NET projects. There is some overhead associated with calling MSBuild to build each project, so Visual Studio uses a "fast up-to-date check" (FUTDC) to avoid calling MSBuild unless needed. This FUTDC can quickly determine if anything has changed in the project that would cause a build to be required. For more information, see [Up-to-date Check](https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md).
> 
> In several cases, the FUTDC identifies that no compilation is required, yet identifies some files need to be copied to the output directory, either from the current project or from a referenced one. Historically in this scenario, the FUTDC would call MSBuild to build the project, even though no compilation was required. This was done to ensure that the files were copied to the output directory.
> 
> With the build acceleration feature, Visual Studio will perform these files copies directly rather than calling MSBuild to do them.
 
### Additional Information

⚠️ Before approving/merging this PR, please test this on Visual Studio v17.5 to confirm we don't accidentally break anything for our users.

I have tested and confirmed this is working on Visual Studio Preview v17.6.

But I am unable to test Visual Studio v17.5 on PC because I am using an ARM-based laptop (MacBook Pro M2 running Windows 11 in a VM via Parallels), and [Visual Studio on ARM64 only supports .NET MAUI in v17.6+](https://developercommunity.visualstudio.com/t/Arm64-support-for-NET-Maui/10107707).