### PR TITLE
Update AbsoluteLayout Flags Extensions

### DIFF
--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -11,7 +11,8 @@ sealed class SettingsPage : BaseContentPage<SettingsViewModel>
 			Children =
 			{
 				new Image().Source("dotnet_bot.png").Opacity(0.25).IsOpaque(false).Aspect(Aspect.AspectFit)
-					.LayoutFlags(AbsoluteLayoutFlags.SizeProportional | AbsoluteLayoutFlags.PositionProportional)
+					.LayoutFlags(AbsoluteLayoutFlags.SizeProportional)
+					.LayoutFlags(AbsoluteLayoutFlags.PositionProportional)
 					.LayoutBounds(0.5, 0.5, 0.5, 0.5)
 					.AutomationIsInAccessibleTree(false),
 
@@ -27,7 +28,7 @@ sealed class SettingsPage : BaseContentPage<SettingsViewModel>
 				new Entry { Keyboard = Keyboard.Numeric }
 					.BackgroundColor(Colors.White)
 					.Placeholder($"Provide a value between {SettingsService.MinimumStoriesToFetch} and {SettingsService.MaximumStoriesToFetch}", Colors.Grey)
-					.LayoutFlags(AbsoluteLayoutFlags.XProportional | AbsoluteLayoutFlags.WidthProportional)
+					.LayoutFlags(AbsoluteLayoutFlags.XProportional, AbsoluteLayoutFlags.WidthProportional)
 					.LayoutBounds(0.5, 45, 0.8, 40)
 					.Behaviors(new NumericValidationBehavior
 					{

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -12,8 +12,7 @@ sealed class SettingsPage : BaseContentPage<SettingsViewModel>
 			{
 				new Image().Source("dotnet_bot.png").Opacity(0.25).IsOpaque(false).Aspect(Aspect.AspectFit)
 					.ClearLayoutFlags()
-					.LayoutFlags(AbsoluteLayoutFlags.SizeProportional)
-					.LayoutFlags(AbsoluteLayoutFlags.PositionProportional)
+					.LayoutFlags(AbsoluteLayoutFlags.SizeProportional | AbsoluteLayoutFlags.PositionProportional)
 					.LayoutBounds(0.5, 0.5, 0.5, 0.5)
 					.AutomationIsInAccessibleTree(false),
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/Pages/SettingsPage.cs
@@ -11,6 +11,7 @@ sealed class SettingsPage : BaseContentPage<SettingsViewModel>
 			Children =
 			{
 				new Image().Source("dotnet_bot.png").Opacity(0.25).IsOpaque(false).Aspect(Aspect.AspectFit)
+					.ClearLayoutFlags()
 					.LayoutFlags(AbsoluteLayoutFlags.SizeProportional)
 					.LayoutFlags(AbsoluteLayoutFlags.PositionProportional)
 					.LayoutBounds(0.5, 0.5, 0.5, 0.5)

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/AbsoluteLayoutExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/AbsoluteLayoutExtensionsTests.cs
@@ -77,4 +77,20 @@ class AbsoluteLayoutExtensionsTest : BaseMarkupTestFixture<BoxView>
 			b.LayoutBounds(100, 100, 100, 100);
 		},
 		(AbsoluteLayout.LayoutBoundsProperty, new Rect(100, 100, 100, 100)));
+
+	// Cannot use TestPropertiesSet() because ClearLayoutFlags sets AbsoluteLayout.LayoutFlagsProperty to its default 
+	[Test]
+	public void ClearLayoutFlags()
+	{
+		var label = new Label().ClearLayoutFlags();
+		Assert.AreEqual(AbsoluteLayoutFlags.None, label.GetPropertyIfSet(AbsoluteLayout.LayoutFlagsProperty, (AbsoluteLayoutFlags)(-1)));
+	}
+
+	// Cannot use TestPropertiesSet() because ClearLayoutFlags sets AbsoluteLayout.LayoutFlagsProperty to its default 
+	[Test]
+	public void ClearLayoutFlagsAfterSettingLayoutFlags()
+	{
+		var label = new Label().LayoutFlags(AbsoluteLayoutFlags.XProportional).ClearLayoutFlags();
+		Assert.AreEqual(AbsoluteLayoutFlags.None, label.GetPropertyIfSet(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.XProportional));
+	}
 }

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/AbsoluteLayoutExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/AbsoluteLayoutExtensionsTests.cs
@@ -13,6 +13,21 @@ class AbsoluteLayoutExtensionsTest : BaseMarkupTestFixture<BoxView>
 		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional));
 
 	[Test]
+	public void MultipleLayoutFlagsUsingBooleanLogic() => TestPropertiesSet(
+		b => b.LayoutFlags(AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional),
+		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional));
+
+	[Test]
+	public void MultipleLayoutFlagsUsingMultipleAPICalls() => TestPropertiesSet(
+		b => b.LayoutFlags(AbsoluteLayoutFlags.PositionProportional).LayoutFlags(AbsoluteLayoutFlags.XProportional),
+		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional));
+
+	[Test]
+	public void MultipleLayoutFlagsUsingParams() => TestPropertiesSet(
+		b => b.LayoutFlags(AbsoluteLayoutFlags.PositionProportional, AbsoluteLayoutFlags.XProportional),
+		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional));
+
+	[Test]
 	public void LayoutBoundsPositionOnlyDouble() => TestPropertiesSet(
 		b =>
 		{

--- a/src/CommunityToolkit.Maui.Markup.UnitTests/AbsoluteLayoutExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/AbsoluteLayoutExtensionsTests.cs
@@ -18,11 +18,6 @@ class AbsoluteLayoutExtensionsTest : BaseMarkupTestFixture<BoxView>
 		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional));
 
 	[Test]
-	public void MultipleLayoutFlagsUsingMultipleAPICalls() => TestPropertiesSet(
-		b => b.LayoutFlags(AbsoluteLayoutFlags.PositionProportional).LayoutFlags(AbsoluteLayoutFlags.XProportional),
-		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional));
-
-	[Test]
 	public void MultipleLayoutFlagsUsingParams() => TestPropertiesSet(
 		b => b.LayoutFlags(AbsoluteLayoutFlags.PositionProportional, AbsoluteLayoutFlags.XProportional),
 		(AbsoluteLayout.LayoutFlagsProperty, AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.XProportional));

--- a/src/CommunityToolkit.Maui.Markup/AbsoluteLayoutExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/AbsoluteLayoutExtensions.cs
@@ -39,6 +39,9 @@ public static class AbsoluteLayoutExtensions
 	/// <summary>
 	/// Set an <see cref="AbsoluteLayoutFlags"/> that indicates whether the layout bounds position and size values for a child are proportional to the size of the <see cref="AbsoluteLayout"/>.
 	/// </summary>
+	/// <remarks>
+	/// To clear existing <see cref="AbsoluteLayoutFlags"/>, use <see cref="ClearLayoutFlags{TBindable}(TBindable)"/>
+	/// </remarks>
 	/// <typeparam name="TBindable"></typeparam>
 	/// <param name="bindable"></param>
 	/// <param name="flags"></param>

--- a/src/CommunityToolkit.Maui.Markup/AbsoluteLayoutExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/AbsoluteLayoutExtensions.cs
@@ -8,15 +8,54 @@ namespace CommunityToolkit.Maui.Markup;
 public static class AbsoluteLayoutExtensions
 {
 	/// <summary>
-	/// Set an <see cref="AbsoluteLayoutFlags"/> that indicates whether the layout bounds position and size values for a child are proportional to the size of the <see cref="AbsoluteLayout"/>.
+	/// Removes all <see cref="AbsoluteLayoutFlags"/>, reverting to the default configuraion of <see cref="AbsoluteLayoutFlags.None"/>.
 	/// </summary>
+	/// <typeparam name="TBindable"></typeparam>
+	/// <param name="bindable"></param>
+	/// <returns></returns>
+	public static TBindable ClearLayoutFlags<TBindable>(this TBindable bindable) where TBindable : BindableObject
+	{
+		AbsoluteLayout.SetLayoutFlags(bindable, AbsoluteLayoutFlags.None);
+		return bindable;
+	}
+
+	/// <summary>
+	/// Set an <see cref="AbsoluteLayoutFlags"/> that indicates whether the layout bounds position and size values for a child are proportional to the size of the <see cref="AbsoluteLayout"/>.
+	/// Appends <paramref name="flag"/> to existing <see cref="AbsoluteLayoutFlags"/>
+	/// </summary>
+	/// <remarks>
+	/// To clear existing <see cref="AbsoluteLayoutFlags"/>, use <see cref="ClearLayoutFlags{TBindable}(TBindable)"/>
+	/// </remarks>
 	/// <typeparam name="TBindable"></typeparam>
 	/// <param name="bindable"></param>
 	/// <param name="flag"></param>
 	/// <returns></returns>
 	public static TBindable LayoutFlags<TBindable>(this TBindable bindable, AbsoluteLayoutFlags flag) where TBindable : BindableObject
 	{
-		AbsoluteLayout.SetLayoutFlags(bindable, flag);
+		var currentFlags = AbsoluteLayout.GetLayoutFlags(bindable);
+
+		AbsoluteLayout.SetLayoutFlags(bindable, currentFlags | flag);
+		return bindable;
+	}
+
+	/// <summary>
+	/// Set an <see cref="AbsoluteLayoutFlags"/> that indicates whether the layout bounds position and size values for a child are proportional to the size of the <see cref="AbsoluteLayout"/>.
+	/// </summary>
+	/// <typeparam name="TBindable"></typeparam>
+	/// <param name="bindable"></param>
+	/// <param name="flags"></param>
+	/// <returns></returns>
+	public static TBindable LayoutFlags<TBindable>(this TBindable bindable, params AbsoluteLayoutFlags[] flags) where TBindable : BindableObject
+	{
+		var currentFlags = AbsoluteLayout.GetLayoutFlags(bindable);
+		var newFlags = AbsoluteLayoutFlags.None;
+
+		foreach(var flag in flags)
+		{
+			newFlags |= flag;
+		}
+
+		AbsoluteLayout.SetLayoutFlags(bindable, currentFlags | newFlags);
 		return bindable;
 	}
 

--- a/src/CommunityToolkit.Maui.Markup/AbsoluteLayoutExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/AbsoluteLayoutExtensions.cs
@@ -32,9 +32,7 @@ public static class AbsoluteLayoutExtensions
 	/// <returns></returns>
 	public static TBindable LayoutFlags<TBindable>(this TBindable bindable, AbsoluteLayoutFlags flag) where TBindable : BindableObject
 	{
-		var currentFlags = AbsoluteLayout.GetLayoutFlags(bindable);
-
-		AbsoluteLayout.SetLayoutFlags(bindable, currentFlags | flag);
+		AbsoluteLayout.SetLayoutFlags(bindable, flag);
 		return bindable;
 	}
 
@@ -47,7 +45,6 @@ public static class AbsoluteLayoutExtensions
 	/// <returns></returns>
 	public static TBindable LayoutFlags<TBindable>(this TBindable bindable, params AbsoluteLayoutFlags[] flags) where TBindable : BindableObject
 	{
-		var currentFlags = AbsoluteLayout.GetLayoutFlags(bindable);
 		var newFlags = AbsoluteLayoutFlags.None;
 
 		foreach(var flag in flags)
@@ -55,7 +52,7 @@ public static class AbsoluteLayoutExtensions
 			newFlags |= flag;
 		}
 
-		AbsoluteLayout.SetLayoutFlags(bindable, currentFlags | newFlags);
+		AbsoluteLayout.SetLayoutFlags(bindable, newFlags);
 		return bindable;
 	}
 


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Markup Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Markup Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI Markup core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui.markup/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This Proposal adds two new APIs to `AbsoluteLayoutExtensions` and updates the functionality of the existing `.LayoutFlags()` API to add existing `AbsoluteLayoutFlags` instead of overwriting existing `AbsoluteLayoutFlags`.

### 1. New APIs

```cs
public static TBindable ClearLayoutFlags<TBindable>(this TBindable bindable) where TBindable : BindableObject;

public static TBindable LayoutFlags<TBindable>(this TBindable bindable, params AbsoluteLayoutFlags[] flags) where TBindable : BindableObject;
```

### 2. Updating `LayoutFlags` Functionality

#### Current Functionality 

The current functionality of `LayoutFlags` overwrites any existing `AbsoluteLayoutFlags` that are already defined by the `BindableObject`. 

For example, the resulting `AbosluteLayoutFlag` property of the `Label` in the following sample will be only `AbsoluteLayoutFlags.PositionProportional`, because the current functionality overwrites any existing `AbsoluteLayoutFlag`.

```cs
new Label() // The label's final `AbsoluteLayoutFlags` value is `AbsoluteLayoutFlags.PositionProportional`
  .LayoutFlags(AbsoluteLayoutFlags.SizeProportional)
  .LayoutFlags(AbsoluteLayoutFlags.PositionProportional)  // Overwrites existing `AbsoluteLayoutFlags`
```

#### Updated Functionality 

The updated functionality of `LayoutFlags` will append the incoming `AbsoluteLayoutFlags` to every existing `AbsoluteLayoutFlags`.

For example, the resulting `AbosluteLayoutFlag` property of the `Label` in the following sample will be `AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.PositionProportional`, because the incoming value combined with  any existing `AbsoluteLayoutFlag` values using a [bitwise `OR`](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators#logical-or-operator-) operator.

```cs
new Label() // The label's final `AbsoluteLayoutFlags` value is `AbsoluteLayoutFlags.PositionProportional | AbsoluteLayoutFlags.SizeProportional `
  .LayoutFlags(AbsoluteLayoutFlags.SizeProportional)
  .LayoutFlags(AbsoluteLayoutFlags.PositionProportional)  // Combined with existing `AbsoluteLayoutFlags`
```


 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #215

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: [https://github.com/MicrosoftDocs/CommunityToolkit/pulls/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged --> 
](https://github.com/MicrosoftDocs/CommunityToolkit/pull/271)