### PR TITLE
Publish NuGet artifacts only from Windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,7 +183,8 @@ jobs:
 
       # publish the packages
       - task: PublishBuildArtifacts@1
-        displayName: 'Publish Unsigned NuGets'
+        condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows
+        displayName: 'Publish NuGets'
         inputs:
           artifactName: nuget
           pathToPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
### Description of Change ###

While preparing a new release I found out that we are publishing NuGets from both the macOS _and_ the Windows build. But only the Windows build has all the target platforms we need and are the libraries that are signed with a certificate.

The reason we didn't discover this earlier is basically because we got lucky until now. The macOS build is faster than the Windows one. So the macOS build would finish in let's say 10 minutes and produce NuGets, but then Windows would finish a couple of minutes later and override those NuGets and those would be used by a potential release.

This worked fine, until now the macOS build failed and I had to retry it. Once retries, it succeeded, but this time overriding the NuGets (again!) from Windows to the macOS ones. And because of that they were blocked for release because these NuGets aren't signed.

To overcome all this, let's just only produce NuGets from Windows.