### PR TITLE
Ensure `RegisterReloadApplicationEventHandler` Runs in DEBUG Configuration

### DIFF
--- a/src/CommunityToolkit.Maui.Markup/AppBuilderExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/AppBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class AppBuilderExtensions
 		{
 			RegisterReloadApplicationEventHandler();
 		}
+		
 		return builder;
 	}
 	

--- a/src/CommunityToolkit.Maui.Markup/AppBuilderExtensions.cs
+++ b/src/CommunityToolkit.Maui.Markup/AppBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace CommunityToolkit.Maui.Markup;
+﻿using System.Diagnostics;
+
+namespace CommunityToolkit.Maui.Markup;
 
 /// <summary>
 /// <see cref="MauiAppBuilder"/> Extensions
@@ -12,11 +14,13 @@ public static class AppBuilderExtensions
 	/// <returns><see cref="MauiAppBuilder"/> initialized for <see cref="CommunityToolkit.Maui.Markup"/></returns>
 	public static MauiAppBuilder UseMauiCommunityToolkitMarkup(this MauiAppBuilder builder)
 	{
-		RegisterReloadApplicationEventHandler();
+		if (Debugger.IsAttached)
+		{
+			RegisterReloadApplicationEventHandler();
+		}
 		return builder;
 	}
-
-	[System.Diagnostics.Conditional("DEBUG")]
+	
 	static void RegisterReloadApplicationEventHandler()
 	{
 		CommunityToolkitMetadataUpdateHandler.ReloadApplication += ReloadApplication;


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Markup Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Markup Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI Markup core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui.markup/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui.Markup/discussions/261

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)

 
