### PR TITLE
[Sample App] Add Microsoft.Extensions.Http.Resilience

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,12 @@ csharp_style_namespace_declarations = file_scoped:error
 # CS4014: Because this call is not awaited, execution of the current method continues before the call is completed
 dotnet_diagnostic.CS4014.severity = error
 
+# CS2012: ValueTask instances returned from member invocations are intended to be directly awaited. Attempts to consume a ValueTask multiple times or to directly access one's result before it's known to be completed may result in an exception or corruption. Ignoring such a ValueTask is likely an indication of a functional bug and may degrade performance.
+dotnet_diagnostic.CS2012.severity = error
+
+# CS1998 : This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.
+dotnet_diagnostic.CS1998.severity = error
+
 # Remove explicit default access modifiers
 dotnet_style_require_accessibility_modifiers = omit_if_default:error
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,25 +13,33 @@
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <IsTrimmable>false</IsTrimmable>
+
     <!-- WarningsAsErrors
-    CS0419: Ambiguous reference in cref attribute 
-    CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 
-    CS1571: XML comment on [construct] has a duplicate param tag for [parameter] 
-    CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name 
-    CS1573: Parameter has no matching param tag in the XML comment 
-    CS1574: XML comment has cref attribute that could not be resolved 
-    CS1580: Invalid type for parameter 'parameter number' in XML comment cref attribute 
-    CS1581: Invalid return type in XML comment cref attribute 
-    CS1584: XML comment has syntactically incorrect cref attribute 
-    CS1589: The syntax of a tag which referenced a file was incorrect 
-    CS1590: Invalid XML include element Missing file attribute 
-    CS1592: Badly formed XML in included comments file 
-    CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
-    CS1658: Identifier expected; 'true' is a keyword 
-    CS1734: XML comment has a paramref tag, but there is no parameter by that name 
-    NUnit2007: Warning NUnit2007 : The actual value should not be a constant - perhaps the actual value and the expected value have switched places
-    NUnit2045: Hosting Asserts inside an Assert.Multiple allows detecting more than one failure-->
-    <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1589,CS1590,CS1592,CS1598,CS1658,CS1734,NUnit2007,NUnit2045</WarningsAsErrors>
+     CS0419: Ambiguous reference in cref attribute 
+     CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 
+     CS1571: XML comment on [construct] has a duplicate param tag for [parameter] 
+     CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name 
+     CS1573: Parameter has no matching param tag in the XML comment 
+     CS1574: XML comment has cref attribute that could not be resolved 
+     CS1580: Invalid type for parameter 'parameter number' in XML comment cref attribute 
+     CS1581: Invalid return type in XML comment cref attribute 
+     CS1584: XML comment has syntactically incorrect cref attribute
+     CS1587: XML comment is not placed on a valid language element 
+     CS1589: The syntax of a tag which referenced a file was incorrect 
+     CS1590: Invalid XML include element Missing file attribute 
+     CS1591: Missing XML comment for publicly visible type or member
+     CS1592: Badly formed XML in included comments file 
+     CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
+     CS1658: Identifier expected; 'true' is a keyword
+     CS1710: XML comment on 'type' has a duplicate typeparam tag for 'parameter'
+     CS1711: XML comment has a typeparam tag, but there is no type parameter by that name 
+     CS1712: Type parameter has no matching typeparam tag in the XML comment
+     CS1723: XML comment has cref attribute that refers to a type parameter
+     CS1734: XML comment has a paramref tag, but there is no parameter by that name 
+     xUnit1012: Null should not be used for type parameter
+     xUnit2021: Assert.ThrowsAsync is async. The resulting task should be awaited -->
+    <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1587,CS1589,CS1590,CS1591,CS1592,CS1598,CS1658,CS1710,CS1711,CS1712,CS1723,CS1734,xUnit1012,xUnit2021</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NetVersion>net8.0</NetVersion>
-    <MauiPackageVersion>8.0.10</MauiPackageVersion>
+    <MauiPackageVersion>8.0.14</MauiPackageVersion>
     <MauiCommunityToolkitPackageVersion>7.0.1</MauiCommunityToolkitPackageVersion>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,14 +89,21 @@ jobs:
       - task: CmdLine@2
         displayName: 'Install .NET MAUI Workload'
         inputs:
-            script : |
-              dotnet --info
-              dotnet workload install maui
+            script : 'dotnet workload install maui'
 
       - pwsh: |
           Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
           .\workload-install.ps1
         displayName: Install Tizen Workload
+
+      # Print Information on the .NET SDK Used By the CI Build Host
+      # These logs are useful information when debugging CI Builds
+      # Note: This step doesn't execute nor modify any code; it is strictly used for logging + debugging purposes
+      - task: CmdLine@2
+        displayName: 'Display dotnet --info'
+        inputs:
+          script: dotnet --info
+
 
       # build
       - task: CmdLine@2
@@ -185,7 +192,7 @@ jobs:
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
 
       # publish the packages
-      - task: PublishBuildArtifacts@1
+      - task: PublishBuildArtifacts@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows
         displayName: 'Publish NuGets'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,6 @@ jobs:
         inputs:
           script: dotnet --info
 
-
       # build
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Markup.SourceGenerators'
@@ -140,7 +139,7 @@ jobs:
           testResultsFiles: '**/*.trx'
           searchFolder: $(Agent.TempDirectory)
           
-      - task: PublishCodeCoverageResults@1
+      - task: PublishCodeCoverageResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows
         displayName: 'Publish Code Coverage Results'
         inputs:
@@ -192,7 +191,7 @@ jobs:
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), not(eq(variables['build.reason'], 'PullRequest')), not(eq(variables['SignClientSecret'], '')), not(eq(variables['SignClientUser'], '')))
 
       # publish the packages
-      - task: PublishBuildArtifacts@2
+      - task: PublishBuildArtifacts@1
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows
         displayName: 'Publish NuGets'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Display dotnet --info'
         inputs:
-          script: dotnet --info
+            script: dotnet --info
 
 
       # build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Install .NET MAUI Workload'
         inputs:
-            script : 'dotnet workload install maui'
+          script : 'dotnet workload install maui'
 
       - pwsh: |
           Invoke-WebRequest 'https://raw.githubusercontent.com/Samsung/Tizen.NET/main/workload/scripts/workload-install.ps1' -OutFile 'workload-install.ps1'
@@ -102,7 +102,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Display dotnet --info'
         inputs:
-            script: dotnet --info
+          script: dotnet --info
 
 
       # build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,22 +108,22 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Markup.SourceGenerators'
         inputs:
-          script: 'dotnet build -c Release $(PathToCommunityToolkitSourceGeneratorsCsproj) -warnaserror'
+          script: 'dotnet build -c Release $(PathToCommunityToolkitSourceGeneratorsCsproj)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Markup'
         inputs:
-          script: 'dotnet build -c Release $(PathToCommunityToolkitCsproj) -warnaserror'
+          script: 'dotnet build -c Release $(PathToCommunityToolkitCsproj)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Markup.Sample'
         inputs:
-          script: 'dotnet build -c Release $(PathToCommunityToolkitSampleCsproj) -warnaserror'
+          script: 'dotnet build -c Release $(PathToCommunityToolkitSampleCsproj)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Markup.UnitTests'
         inputs:
-          script: 'dotnet build -c Release $(PathToCommunityToolkitUnitTestCsproj) -warnaserror'
+          script: 'dotnet build -c Release $(PathToCommunityToolkitUnitTestCsproj)'
 
       # test
       - task: CmdLine@2

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Maui" Version="7.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.1.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
   </ItemGroup>
 

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -40,7 +40,7 @@ public class MauiProgram
 		return builder.Build();
 	}
     
-	class MobileHttpRetryStrategyOptions : HttpRetryStrategyOptions
+	sealed class MobileHttpRetryStrategyOptions : HttpRetryStrategyOptions
 	{
 		public MobileHttpRetryStrategyOptions()
 		{

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Polly;
+﻿using Microsoft.Extensions.Http.Resilience;
+using Polly;
 using Refit;
 
 namespace CommunityToolkit.Maui.Markup.Sample;
@@ -26,7 +27,7 @@ public class MauiProgram
 		builder.Services.AddSingleton<HackerNewsAPIService>();
 		builder.Services.AddRefitClient<IHackerNewsApi>()
 							.ConfigureHttpClient(client => client.BaseAddress = new Uri("https://hacker-news.firebaseio.com/v0"))
-							.AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(3, sleepDurationProvider));
+							.AddStandardResilienceHandler(options => options.Retry = new MobileHttpRetryStrategyOptions());
 
 		// Pages + View Models
 		builder.Services.AddTransient<NewsPage, NewsViewModel>();
@@ -37,7 +38,16 @@ public class MauiProgram
 		builder.Services.AddSingleton<ICommunityToolkitHotReloadHandler, HotReloadHandler>();
 
 		return builder.Build();
-
-		static TimeSpan sleepDurationProvider(int attemptNumber) => TimeSpan.FromSeconds(Math.Pow(2, attemptNumber));
+	}
+    
+	class MobileHttpRetryStrategyOptions : HttpRetryStrategyOptions
+	{
+		public MobileHttpRetryStrategyOptions()
+		{
+			BackoffType = DelayBackoffType.Exponential;
+			MaxRetryAttempts = 3;
+			UseJitter = true;
+			Delay = TimeSpan.FromSeconds(2);
+		}
 	}
 }

--- a/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/MauiProgram.cs
@@ -39,7 +39,7 @@ public class MauiProgram
 
 		return builder.Build();
 	}
-    
+
 	sealed class MobileHttpRetryStrategyOptions : HttpRetryStrategyOptions
 	{
 		public MobileHttpRetryStrategyOptions()


### PR DESCRIPTION
 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

This PR replaces `Microsoft.Extensions.Http.Polly` with `Microsoft.Extensions.Http.Resilience`.

In .NET 8, Microsoft teamed up with the `App-vNext.Polly` team to create a more-performant version of `Polly`.  The new `Microsoft.Extensions.Http.Resilience` library uses the new, more performant version of `Polly`.

Meanwhile `[Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly)` uses the older, less performant, version of `Polly` now rebranded as `Polly.Core.`

To ensure our Sample App adheres to best practices recommended for all .NET MAUI developers, we are upgrading `Microsoft.Extensions.Http.Polly` with `Microsoft.Extensions.Http.Resilience`.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

More information is available in this .NET Blog Post:

https://devblogs.microsoft.com/dotnet/building-resilient-cloud-services-with-dotnet-8/

>Resilience packages
>* [Microsoft.Extensions.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Resilience): This package provides a minimal set of APIs. Its primary purpose is to enrich [Polly’s metrics](https://www.pollydocs.org/advanced/telemetry.html#metrics) using the AddResilienceEnricher extension for IServiceCollection. For more details, refer to the [Resilience docs](https://learn.microsoft.com/dotnet/core/resilience).
> * [Microsoft.Extensions.Http.Resilience](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience): This package offers HTTP-specific APIs that integrate with Polly v8 and IHttpClientFactory. It is the successor to the Microsoft.Extensions.Http.Polly package and is recommended for all new projects. See the section below for more information.
> * [Microsoft.Extensions.Http.Polly](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly): This package integrates older versions of Polly with [HttpClient](https://learn.microsoft.com/dotnet/fundamentals/networking/http/httpclient) and [IHttpClientFactory](https://learn.microsoft.com/dotnet/core/extensions/httpclient-factory).


