### PR TITLE
Enable AOT Support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,32 +16,35 @@
     <IsTrimmable>false</IsTrimmable>
 
     <!-- WarningsAsErrors
-  CS0419: Ambiguous reference in cref attribute 
-  CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 
-  CS1571: XML comment on [construct] has a duplicate param tag for [parameter] 
-  CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name 
-  CS1573: Parameter has no matching param tag in the XML comment 
-  CS1574: XML comment has cref attribute that could not be resolved 
-  CS1580: Invalid type for parameter 'parameter number' in XML comment cref attribute 
-  CS1581: Invalid return type in XML comment cref attribute 
-  CS1584: XML comment has syntactically incorrect cref attribute
-  CS1587: XML comment is not placed on a valid language element 
-  CS1589: The syntax of a tag which referenced a file was incorrect 
-  CS1590: Invalid XML include element Missing file attribute 
-  CS1591: Missing XML comment for publicly visible type or member
-  CS1592: Badly formed XML in included comments file 
-  CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
-  CS1658: Identifier expected; 'true' is a keyword
-  CS1710: XML comment on 'type' has a duplicate typeparam tag for 'parameter'
-  CS1711: XML comment has a typeparam tag, but there is no type parameter by that name 
-  CS1712: Type parameter has no matching typeparam tag in the XML comment
-  CS1723: XML comment has cref attribute that refers to a type parameter
-  CS1734: XML comment has a paramref tag, but there is no parameter by that name
-  IL2***: Trim Warnings
-  IL3***: AOT Warnings -->
+     CS0419: Ambiguous reference in cref attribute 
+     CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 
+     CS1571: XML comment on [construct] has a duplicate param tag for [parameter] 
+     CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name 
+     CS1573: Parameter has no matching param tag in the XML comment 
+     CS1574: XML comment has cref attribute that could not be resolved 
+     CS1580: Invalid type for parameter 'parameter number' in XML comment cref attribute 
+     CS1581: Invalid return type in XML comment cref attribute 
+     CS1584: XML comment has syntactically incorrect cref attribute
+     CS1587: XML comment is not placed on a valid language element 
+     CS1589: The syntax of a tag which referenced a file was incorrect 
+     CS1590: Invalid XML include element Missing file attribute 
+     CS1591: Missing XML comment for publicly visible type or member
+     CS1592: Badly formed XML in included comments file 
+     CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
+     CS1658: Identifier expected; 'true' is a keyword
+     CS1710: XML comment on 'type' has a duplicate typeparam tag for 'parameter'
+     CS1711: XML comment has a typeparam tag, but there is no type parameter by that name 
+     CS1712: Type parameter has no matching typeparam tag in the XML comment
+     CS1723: XML comment has cref attribute that refers to a type parameter
+     CS1734: XML comment has a paramref tag, but there is no parameter by that name 
+     xUnit1012: Null should not be used for type parameter
+     xUnit2021: Assert.ThrowsAsync is async. The resulting task should be awaited 
+     IL2***: Trim Warnings
+     IL3***: AOT Warnings-->
     <WarningsAsErrors>
       nullable,
       CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1587,CS1589,CS1590,CS1591,CS1592,CS1598,CS1658,CS1710,CS1711,CS1712,CS1723,CS1734,
+      xUnit1012,xUnit2021,
       IL2001,IL2002,IL2003,IL2004,IL2005,IL2006,IL2007,IL2008,IL2009,
       IL2010,IL2011,IL2012,IL2013,IL2014,IL2015,IL2016,IL2017,IL2018,IL2019,
       IL2020,IL2021,IL2022,IL2023,IL2024,IL2025,IL2026,IL2027,IL2028,IL2029,
@@ -56,8 +59,7 @@
       IL2110,IL2111,IL2112,IL2113,IL2114,IL2115,IL2116,IL2117,IL2118,IL2119,
       IL2120,IL2121,IL2122,
       IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056
-    </WarningsAsErrors>
-  </PropertyGroup>
+      </WarningsAsErrors>  </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="CommunityToolkit.Maui.Markup.UnitTests" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,10 @@
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <IsTrimmable>false</IsTrimmable>
+    
+    <!-- https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows -->
+    <StripSymbols>false</StripSymbols>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
 
     <!-- WarningsAsErrors
      CS0419: Ambiguous reference in cref attribute 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -59,7 +59,8 @@
       IL2110,IL2111,IL2112,IL2113,IL2114,IL2115,IL2116,IL2117,IL2118,IL2119,
       IL2120,IL2121,IL2122,
       IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056
-      </WarningsAsErrors>  </PropertyGroup>
+      </WarningsAsErrors>  
+  </PropertyGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="CommunityToolkit.Maui.Markup.UnitTests" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,30 +16,47 @@
     <IsTrimmable>false</IsTrimmable>
 
     <!-- WarningsAsErrors
-     CS0419: Ambiguous reference in cref attribute 
-     CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 
-     CS1571: XML comment on [construct] has a duplicate param tag for [parameter] 
-     CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name 
-     CS1573: Parameter has no matching param tag in the XML comment 
-     CS1574: XML comment has cref attribute that could not be resolved 
-     CS1580: Invalid type for parameter 'parameter number' in XML comment cref attribute 
-     CS1581: Invalid return type in XML comment cref attribute 
-     CS1584: XML comment has syntactically incorrect cref attribute
-     CS1587: XML comment is not placed on a valid language element 
-     CS1589: The syntax of a tag which referenced a file was incorrect 
-     CS1590: Invalid XML include element Missing file attribute 
-     CS1591: Missing XML comment for publicly visible type or member
-     CS1592: Badly formed XML in included comments file 
-     CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
-     CS1658: Identifier expected; 'true' is a keyword
-     CS1710: XML comment on 'type' has a duplicate typeparam tag for 'parameter'
-     CS1711: XML comment has a typeparam tag, but there is no type parameter by that name 
-     CS1712: Type parameter has no matching typeparam tag in the XML comment
-     CS1723: XML comment has cref attribute that refers to a type parameter
-     CS1734: XML comment has a paramref tag, but there is no parameter by that name 
-     xUnit1012: Null should not be used for type parameter
-     xUnit2021: Assert.ThrowsAsync is async. The resulting task should be awaited -->
-    <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1587,CS1589,CS1590,CS1591,CS1592,CS1598,CS1658,CS1710,CS1711,CS1712,CS1723,CS1734,xUnit1012,xUnit2021</WarningsAsErrors>
+  CS0419: Ambiguous reference in cref attribute 
+  CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] 
+  CS1571: XML comment on [construct] has a duplicate param tag for [parameter] 
+  CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name 
+  CS1573: Parameter has no matching param tag in the XML comment 
+  CS1574: XML comment has cref attribute that could not be resolved 
+  CS1580: Invalid type for parameter 'parameter number' in XML comment cref attribute 
+  CS1581: Invalid return type in XML comment cref attribute 
+  CS1584: XML comment has syntactically incorrect cref attribute
+  CS1587: XML comment is not placed on a valid language element 
+  CS1589: The syntax of a tag which referenced a file was incorrect 
+  CS1590: Invalid XML include element Missing file attribute 
+  CS1591: Missing XML comment for publicly visible type or member
+  CS1592: Badly formed XML in included comments file 
+  CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
+  CS1658: Identifier expected; 'true' is a keyword
+  CS1710: XML comment on 'type' has a duplicate typeparam tag for 'parameter'
+  CS1711: XML comment has a typeparam tag, but there is no type parameter by that name 
+  CS1712: Type parameter has no matching typeparam tag in the XML comment
+  CS1723: XML comment has cref attribute that refers to a type parameter
+  CS1734: XML comment has a paramref tag, but there is no parameter by that name
+  IL2***: Trim Warnings
+  IL3***: AOT Warnings -->
+    <WarningsAsErrors>
+      nullable,
+      CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1587,CS1589,CS1590,CS1591,CS1592,CS1598,CS1658,CS1710,CS1711,CS1712,CS1723,CS1734,
+      IL2001,IL2002,IL2003,IL2004,IL2005,IL2006,IL2007,IL2008,IL2009,
+      IL2010,IL2011,IL2012,IL2013,IL2014,IL2015,IL2016,IL2017,IL2018,IL2019,
+      IL2020,IL2021,IL2022,IL2023,IL2024,IL2025,IL2026,IL2027,IL2028,IL2029,
+      IL2030,IL2031,IL2032,IL2033,IL2034,IL2035,IL2036,IL2037,IL2038,IL2039,
+      IL2040,IL2041,IL2042,IL2043,IL2044,IL2045,IL2046,IL2047,IL2048,IL2049,
+      IL2050,IL2051,IL2052,IL2053,IL2054,IL2055,IL2056,IL2057,IL2058,IL2059,
+      IL2060,IL2061,IL2062,IL2063,IL2064,IL2065,IL2066,IL2067,IL2068,IL2069,
+      IL2070,IL2071,IL2072,IL2073,IL2074,IL2075,IL2076,IL2077,IL2078,IL2079,
+      IL2080,IL2081,IL2082,IL2083,IL2084,IL2085,IL2086,IL2087,IL2088,IL2089,
+      IL2090,IL2091,IL2092,IL2093,IL2094,IL2095,IL2096,IL2097,IL2098,IL2099,
+      IL2100,IL2101,IL2102,IL2103,IL2104,IL2105,IL2106,IL2107,IL2108,IL2109,
+      IL2110,IL2111,IL2112,IL2113,IL2114,IL2115,IL2116,IL2117,IL2118,IL2119,
+      IL2120,IL2121,IL2122,
+      IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056
+    </WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/CommunityToolkit.Maui.Markup.Sample/AppShell.cs
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/AppShell.cs
@@ -1,4 +1,6 @@
-﻿namespace CommunityToolkit.Maui.Markup.Sample;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace CommunityToolkit.Maui.Markup.Sample;
 
 class AppShell : Shell
 {
@@ -30,7 +32,7 @@ class AppShell : Shell
 		return route;
 	}
 
-	static KeyValuePair<Type, string> CreateRoutePageMapping<TPage, TViewModel>() where TPage : BaseContentPage<TViewModel>
+	static KeyValuePair<Type, string> CreateRoutePageMapping<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TPage, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TViewModel>() where TPage : BaseContentPage<TViewModel>
 																					where TViewModel : BaseViewModel
 	{
 		var route = CreateRoute();

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -29,6 +29,14 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release' 
+                  AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'tizen'
+                  AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">
+    <!-- Ahead-of-time compilation is not yet supported net8.0-tizen -->
+    <!-- Cross-OS native compilation is not supported net8.0-android -->
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- App Icon -->
     <MauiIcon Include="Resources\appicon.svg" ForegroundFile="Resources\appiconfg.svg" Color="#512BD4" />

--- a/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Markup.Sample/CommunityToolkit.Maui.Markup.Sample.csproj
@@ -31,9 +31,11 @@
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' 
                   AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'tizen'
-                  AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'">
+                  AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'android'
+                  AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">
     <!-- Ahead-of-time compilation is not yet supported net8.0-tizen -->
     <!-- Cross-OS native compilation is not supported net8.0-android -->
+    <!-- net8.0-windows causing build errors in azurepipelines.yml -->
     <PublishAot>true</PublishAot>
   </PropertyGroup>
 

--- a/src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj
+++ b/src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>$(NetVersion)</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <IsAotCompatible>true</IsAotCompatible>
+		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj
+++ b/src/CommunityToolkit.Maui.Markup/CommunityToolkit.Maui.Markup.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>$(NetVersion)</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/CommunityToolkit.Maui.Markup/GridRowsColumns.cs
+++ b/src/CommunityToolkit.Maui.Markup/GridRowsColumns.cs
@@ -127,9 +127,9 @@ public static class GridRowsColumns
 	/// <returns>Count of enum values</returns>
 	/// <exception cref="ArgumentNullException"></exception>
 	/// <exception cref="InvalidOperationException"></exception>
-	public static int All<TEnum>() where TEnum : Enum
+	public static int All<TEnum>() where TEnum : struct, Enum
 	{
-		var values = Enum.GetValues(typeof(TEnum)) ?? throw new ArgumentNullException(nameof(TEnum));
+		var values = Enum.GetValues<TEnum>();
 		int span = 1 + (int)(values.GetValue(values.Length - 1) ?? throw new InvalidOperationException("Value Not Found"));
 
 		return span;
@@ -141,9 +141,9 @@ public static class GridRowsColumns
 	/// <typeparam name="TEnum"></typeparam>
 	/// <returns>Last value in Enum</returns>
 	/// <exception cref="InvalidOperationException"></exception>
-	public static int Last<TEnum>() where TEnum : Enum
+	public static int Last<TEnum>() where TEnum : struct, Enum
 	{
-		var values = Enum.GetValues(typeof(TEnum));
+		var values = Enum.GetValues<TEnum>();
 		int last = (int)(values.GetValue(values.Length - 1) ?? throw new InvalidOperationException("Value Not Found"));
 
 		return last;


### PR DESCRIPTION
 ### Description of Change ###

This PR enables Full AOT for `CommunityToolkit.Maui.Markup` by adding `<IsAotCompatible>true</IsAotCompatible>`.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This PR promotes all of the Trimmer + AOT analyzer warnings to errors in `<warningsaserrors>` inside `Directory.Build.props` to ensure we don't accidentally inject non-AOT Safe code in future PRs.

This PR also enables `<PublushAot>` for Release builds of `CommunityToolkit.Maui.Markup.Sample` to ensure our sample continues to run nominally while using AOT and  does not break in future releases.


