### PR TITLE
Add String-based Gesture Extensions

### DIFF
--- a/src/CommunityToolkit.Maui.Markup.UnitTests/GesturesExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.Markup.UnitTests/GesturesExtensionsTests.cs
@@ -220,7 +220,8 @@ class GesturesExtensionsTypedBindingsTests<TGestureElement> : BaseMarkupTestFixt
 		gestureElement.BindTapGesture(
 			getter: static (ViewModel vm) => vm.NestedCommand.SetGuidCommand,
 			[
-				(static vm => vm, nameof(ViewModel.NestedCommand)), (vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
+				(static vm => vm, nameof(ViewModel.NestedCommand)),
+				(static vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
 			],
 			mode: BindingMode.OneTime);
 
@@ -285,13 +286,15 @@ class GesturesExtensionsTypedBindingsTests<TGestureElement> : BaseMarkupTestFixt
 		gestureElement.BindTapGesture(
 			getter: static (ViewModel vm) => vm.NestedCommand.SetGuidCommand,
 			[
-				(static vm => vm, nameof(ViewModel.NestedCommand)), (vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
+				(static vm => vm, nameof(ViewModel.NestedCommand)),
+				(static vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
 			],
 			commandBindingMode: BindingMode.OneTime,
 			parameterGetter: static (ViewModel vm) => vm.NestedCommand.Id,
 			parameterHandlers:
 			[
-				(static vm => vm, nameof(ViewModel.NestedCommand)), (vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.Id))
+				(static vm => vm, nameof(ViewModel.NestedCommand)),
+				(static vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.Id))
 			],
 			numberOfTapsRequired: numberOfTaps);
 
@@ -334,7 +337,8 @@ class GesturesExtensionsTypedBindingsTests<TGestureElement> : BaseMarkupTestFixt
 		gestureElement.BindSwipeGesture(
 			getter: static (ViewModel vm) => vm.NestedCommand.SetGuidCommand,
 			[
-				(static vm => vm, nameof(ViewModel.NestedCommand)), (vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
+				(static vm => vm, nameof(ViewModel.NestedCommand)),
+				(static vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
 			],
 			mode: BindingMode.OneTime);
 
@@ -403,13 +407,15 @@ class GesturesExtensionsTypedBindingsTests<TGestureElement> : BaseMarkupTestFixt
 		gestureElement.BindSwipeGesture(
 			getter: static (ViewModel vm) => vm.NestedCommand.SetGuidCommand,
 			[
-				(static vm => vm, nameof(ViewModel.NestedCommand)), (vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
+				(static vm => vm, nameof(ViewModel.NestedCommand)),
+				(static vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.SetGuidCommand))
 			],
 			commandBindingMode: BindingMode.OneTime,
 			parameterGetter: static (ViewModel vm) => vm.NestedCommand.Id,
 			parameterHandlers:
 			[
-				(static vm => vm, nameof(ViewModel.NestedCommand)), (vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.Id))
+				(static vm => vm, nameof(ViewModel.NestedCommand)),
+				(static vm => vm.NestedCommand, nameof(ViewModel.NestedCommand.Id))
 			],
 			direction: direction,
 			threshold: threshold);

--- a/src/CommunityToolkit.Maui.Markup/GesturesExtensions.TypedBindings.cs
+++ b/src/CommunityToolkit.Maui.Markup/GesturesExtensions.TypedBindings.cs
@@ -1,0 +1,298 @@
+﻿using System.Linq.Expressions;
+using System.Windows.Input;
+namespace CommunityToolkit.Maui.Markup;
+
+/// <summary>
+/// Extension Methods for Element Gestures
+/// </summary>
+public static partial class GesturesExtensions
+{
+	/// <summary>Add a <see cref="SwipeGestureRecognizer"/> and bind to its Command </summary>
+	public static TGestureElement BindSwipeGesture<TGestureElement, TCommandBindingContext>(
+		this TGestureElement gestureElement,
+		Expression<Func<TCommandBindingContext, ICommand>> getter,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode mode = BindingMode.Default,
+		SwipeDirection? direction = null,
+		uint? threshold = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+	{
+		return BindSwipeGesture<TGestureElement, TCommandBindingContext, object, object?>(
+			gestureElement,
+			getter,
+			setter,
+			source,
+			mode,
+			direction: direction,
+			threshold: threshold);
+	}
+
+	/// <summary>Add a <see cref="SwipeGestureRecognizer"/> and bind to its Command and (optionally) CommandParameter properties</summary>
+	public static TGestureElement BindSwipeGesture<TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+		this TGestureElement gestureElement,
+		Expression<Func<TCommandBindingContext, ICommand>> getter,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
+		Expression<Func<TParameterBindingContext, TParameterSource>>? parameterGetter = null,
+		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
+		BindingMode parameterBindingMode = BindingMode.Default,
+		TParameterBindingContext? parameterSource = default,
+		SwipeDirection? direction = null,
+		uint? threshold = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+		where TParameterBindingContext : class
+	{
+		var getterFunc = ConvertExpressionToFunc(getter);
+		var parameterGetterFunc = parameterGetter switch
+		{
+			null => null,
+			_ => ConvertExpressionToFunc(parameterGetter)
+		};
+
+		(Func<TParameterBindingContext, object?>, string)[]? parameterGetterHandlers = parameterGetter switch
+		{
+			null => null,
+			_ => [(b => b, GetMemberName(parameterGetter))]
+		};
+
+		return BindSwipeGesture(
+			gestureElement,
+			getterFunc,
+			[
+				(b => b, GetMemberName(getter))
+			],
+			setter,
+			source,
+			commandBindingMode,
+			parameterGetterFunc,
+			parameterGetterHandlers,
+			parameterSetter,
+			parameterBindingMode,
+			parameterSource,
+			direction,
+			threshold);
+	}
+
+	/// <summary>Add a <see cref="SwipeGestureRecognizer"/> and bind to its Command</summary>
+	public static TGestureElement BindSwipeGesture<TGestureElement, TCommandBindingContext>(
+		this TGestureElement gestureElement,
+		Func<TCommandBindingContext, ICommand> getter,
+		(Func<TCommandBindingContext, object?>, string)[] handlers,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode mode = BindingMode.Default,
+		SwipeDirection? direction = null,
+		uint? threshold = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+	{
+		return gestureElement.BindSwipeGesture<TGestureElement, TCommandBindingContext, object, object?>(
+			getter,
+			handlers,
+			setter,
+			source,
+			mode,
+			direction: direction,
+			threshold: threshold);
+	}
+
+	/// <summary>Add a <see cref="SwipeGestureRecognizer"/> and bind to its Command and (optionally) CommandParameter properties</summary>
+	public static TGestureElement BindSwipeGesture<TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+		this TGestureElement gestureElement,
+		Func<TCommandBindingContext, ICommand> getter,
+		(Func<TCommandBindingContext, object?>, string)[] handlers,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
+		Func<TParameterBindingContext, TParameterSource>? parameterGetter = null,
+		(Func<TParameterBindingContext, object?>, string)[]? parameterHandlers = null,
+		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
+		BindingMode parameterBindingMode = BindingMode.Default,
+		TParameterBindingContext? parameterSource = default,
+		SwipeDirection? direction = null,
+		uint? threshold = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+		where TParameterBindingContext : class
+	{
+		var clickGesture = gestureElement.BindGesture<SwipeGestureRecognizer, TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+			getter,
+			handlers,
+			setter,
+			source,
+			commandBindingMode,
+			parameterGetter,
+			parameterHandlers,
+			parameterSetter,
+			parameterBindingMode,
+			parameterSource);
+
+		return gestureElement.ConfigureSwipeGesture(clickGesture, direction, threshold);
+	}
+
+	/// <summary>Adds a <see cref="TapGestureRecognizer"/> and bind its Command</summary>
+	public static TGestureElement BindTapGesture<TGestureElement, TCommandBindingContext>(
+		this TGestureElement gestureElement,
+		Expression<Func<TCommandBindingContext, ICommand>> getter,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode mode = BindingMode.Default,
+		int? numberOfTapsRequired = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+	{
+
+		return BindTapGesture<TGestureElement, TCommandBindingContext, object, object?>(
+			gestureElement,
+			getter,
+			setter,
+			source,
+			mode,
+			numberOfTapsRequired: numberOfTapsRequired);
+	}
+
+	/// <summary>Adds a <see cref="TapGestureRecognizer"/> and bind its Command and (optionally) CommandParameter properties</summary>
+	public static TGestureElement BindTapGesture<TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+		this TGestureElement gestureElement,
+		Expression<Func<TCommandBindingContext, ICommand>> getter,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
+		Expression<Func<TParameterBindingContext, TParameterSource>>? parameterGetter = null,
+		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
+		BindingMode parameterBindingMode = BindingMode.Default,
+		TParameterBindingContext? parameterSource = default,
+		int? numberOfTapsRequired = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+		where TParameterBindingContext : class
+	{
+		var getterFunc = ConvertExpressionToFunc(getter);
+		var parameterGetterFunc = parameterGetter switch
+		{
+			null => null,
+			_ => ConvertExpressionToFunc(parameterGetter)
+		};
+
+		(Func<TParameterBindingContext, object?>, string)[]? parameterGetterHandlers = parameterGetter switch
+		{
+			null => null,
+			_ => [(b => b, GetMemberName(parameterGetter))]
+		};
+
+		return BindTapGesture(
+			gestureElement,
+			getterFunc,
+			[
+				(b => b, GetMemberName(getter))
+			],
+			setter,
+			source,
+			commandBindingMode,
+			parameterGetterFunc,
+			parameterGetterHandlers,
+			parameterSetter,
+			parameterBindingMode,
+			parameterSource,
+			numberOfTapsRequired);
+	}
+
+	/// <summary>Adds a <see cref="TapGestureRecognizer"/> and bind its Command </summary>
+	public static TGestureElement BindTapGesture<TGestureElement, TCommandBindingContext>(
+		this TGestureElement gestureElement,
+		Func<TCommandBindingContext, ICommand> getter,
+		(Func<TCommandBindingContext, object?>, string)[] handlers,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode mode = BindingMode.Default,
+		int? numberOfTapsRequired = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+	{
+		return gestureElement.BindTapGesture<TGestureElement, TCommandBindingContext, object, object?>(
+			getter,
+			handlers,
+			setter,
+			source,
+			mode,
+			numberOfTapsRequired: numberOfTapsRequired);
+	}
+
+	/// <summary>Adds a <see cref="TapGestureRecognizer"/> and bind its Command and (optionally) CommandParameter properties</summary>
+	public static TGestureElement BindTapGesture<TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+		this TGestureElement gestureElement,
+		Func<TCommandBindingContext, ICommand> getter,
+		(Func<TCommandBindingContext, object?>, string)[] handlers,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
+		Func<TParameterBindingContext, TParameterSource>? parameterGetter = null,
+		(Func<TParameterBindingContext, object?>, string)[]? parameterHandlers = null,
+		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
+		BindingMode parameterBindingMode = BindingMode.Default,
+		TParameterBindingContext? parameterSource = default,
+		int? numberOfTapsRequired = null)
+		where TGestureElement : BindableObject, IGestureRecognizers
+		where TCommandBindingContext : class
+		where TParameterBindingContext : class
+	{
+		var tapGesture = gestureElement.BindGesture<TapGestureRecognizer, TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+			getter,
+			handlers,
+			setter,
+			source,
+			commandBindingMode,
+			parameterGetter,
+			parameterHandlers,
+			parameterSetter,
+			parameterBindingMode,
+			parameterSource);
+
+		return gestureElement.ConfigureTapGesture(tapGesture, numberOfTapsRequired);
+	}
+
+	static Func<TBindingContext, TSource> ConvertExpressionToFunc<TBindingContext, TSource>(in Expression<Func<TBindingContext, TSource>> expression) => expression.Compile();
+
+	static string GetMemberName<T>(in Expression<T> expression) => expression.Body switch
+	{
+		MemberExpression m => m.Member.Name,
+		UnaryExpression { Operand: MemberExpression m } => m.Member.Name,
+		_ => throw new InvalidOperationException("Invalid getter. The `getter` parameter must point directly to a property in the ViewModel and cannot add additional logic")
+	};
+
+	static TGestureRecognizer BindGesture<TGestureRecognizer, TGestureElement, TCommandBindingContext, TParameterBindingContext, TParameterSource>(
+		this TGestureElement gestureElement,
+		Func<TCommandBindingContext, ICommand> getter,
+		(Func<TCommandBindingContext, object?>, string)[] handlers,
+		Action<TCommandBindingContext, ICommand>? setter = null,
+		TCommandBindingContext? source = default,
+		BindingMode commandBindingMode = BindingMode.Default,
+		Func<TParameterBindingContext, TParameterSource>? parameterGetter = null,
+		(Func<TParameterBindingContext, object?>, string)[]? parameterHandlers = null,
+		Action<TParameterBindingContext, TParameterSource>? parameterSetter = null,
+		BindingMode parameterBindingMode = BindingMode.Default,
+		TParameterBindingContext? parameterSource = default)
+		where TGestureElement : IGestureRecognizers
+		where TGestureRecognizer : BindableObject, IGestureRecognizer, new()
+		where TCommandBindingContext : class
+		where TParameterBindingContext : class
+	{
+		var gestureRecognizer = new TGestureRecognizer().BindCommand(getter,
+			handlers,
+			setter,
+			source,
+			commandBindingMode,
+			parameterGetter,
+			parameterHandlers,
+			parameterSetter,
+			parameterSource,
+			parameterBindingMode);
+		gestureElement.GestureRecognizers.Add(gestureRecognizer);
+
+		return gestureRecognizer;
+	}
+}


### PR DESCRIPTION
 ### Description of Change ###

This PR adds string-based Gesture Extensions that were mistakenly removed in v5.0.0.

String-based bindings are still valid in .NET MAUI 9.0.0, however they are not trim-safe.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

Added `[RequiresUnreferencedCode("Using bindings with string paths is not trim safe. Use expression-based binding instead.")]` because string-based bingings are not trim-safe.

Moved Typed Bindings Gesture Extensions to `GesturesExtensions.TypedBindings.cs`
