### PR TITLE
Fix RS1038 Warning: Compiler extensions should be implemented in assemblies with compiler-provided references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,7 +66,8 @@
      NU1905	An audit source does not provide a vulnerability database
      NUnit*: NUnit Analyzers 
      IL2***: Trim Warnings
-     IL3***: AOT Warnings-->
+     IL3***: AOT Warnings
+     RS1038: Compiler extensions should be implemented in assemblies with compiler-provided references-->
     <WarningsAsErrors>
       nullable,
       CS0419,CS0618,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1587,CS1589,CS1590,CS1591,CS1592,CS1598,CS1658,CS1710,CS1711,CS1712,CS1723,CS1734,
@@ -91,7 +92,8 @@
       IL2100,IL2101,IL2102,IL2103,IL2104,IL2105,IL2106,IL2107,IL2108,IL2109,
       IL2110,IL2111,IL2112,IL2113,IL2114,IL2115,IL2116,IL2117,IL2118,IL2119,
       IL2120,IL2121,IL2122,
-      IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056
+      IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056,
+      RS1038
     </WarningsAsErrors>
   </PropertyGroup>
 

--- a/src/CommunityToolkit.Maui.Markup.SourceGenerators/CommunityToolkit.Maui.Markup.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.Markup.SourceGenerators/CommunityToolkit.Maui.Markup.SourceGenerators.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="all" IncludeAssets="build; analyzers" />
   </ItemGroup>
 


### PR DESCRIPTION
 ### Description of Change ###

This PR adds `RS1038` to `<WarningsAsErrors>` and replaces `Microsoft.CodeAnalysis.CSharp.Workspaces` -> `Microsoft.CodeAnalysis.CSharp`

Link to RS1038 Docs:
https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md


 ### Additional information ###

Link to Compiler Warnings seen in `CommunityToolkit.Maui`: https://github.com/CommunityToolkit/Maui/actions/runs/15263232470/job/42928522628#step:14:61

> Warning: D:\a\Maui\Maui\src\CommunityToolkit.Maui.Analyzers\UseCommunityToolkitInitializationAnalyzer.cs(9,2): warning RS1038: This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces. The Microsoft.CodeAnalysis.Workspaces assembly is not provided during command line compilation scenarios, so references to it could cause the compiler extension to behave unpredictably. (https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md) [D:\a\Maui\Maui\src\CommunityToolkit.Maui.Analyzers\CommunityToolkit.Maui.Analyzers.csproj]
 
