### PR TITLE
Use NuGet trusted publishing

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -253,6 +253,9 @@ jobs:
     needs: [sign]
     environment: nuget-release-gate # This gates this job until manually approved
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Install .NET SDK
@@ -267,10 +270,16 @@ jobs:
           name: signed-packages
           path: ./packages
 
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to NuGet.org
         run: >
           dotnet nuget push
           **/*.nupkg
           --source https://api.nuget.org/v3/index.json
-          --api-key ${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
           --skip-duplicate


### PR DESCRIPTION
### Description of Change ###

Migrates the NuGet.org release publish step in `.github/workflows/dotnet-build.yml` from the long-lived `NUGET_PACKAGE_PUSH_TOKEN` secret to NuGet trusted publishing via `NuGet/login` and GitHub OIDC.

The NuGet.org trusted publishing configuration has already been taken care of by the requester.

Trusted publishing policy values for NuGet.org:

| Field | Value |
| --- | --- |
| Repository owner | `CommunityToolkit` |
| Repository name | `Maui.Markup` |
| Workflow file name | `dotnet-build.yml` |
| Environment name | `nuget-release-gate` |

Because this workflow uses the `nuget-release-gate` GitHub environment, that environment needs the `NUGET_USER` secret used by `NuGet/login`.

### Linked Issues ###

- N/A - workflow authentication migration.

### PR Checklist ###

- [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal) - N/A, workflow authentication migration
- [ ] Has tests (if omitted, state reason in description) - Workflow-only change; validated with `git diff --check` and a text check that the NuGet.org push no longer uses the old token secret
- [ ] Has samples (if omitted, state reason in description) - N/A
- [ ] Rebased on top of `main` at time of PR
- [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated: N/A

### Additional information ###

Preserves the existing tag-only release flow, `nuget-release-gate` environment gate, signing job, artifact download path, NuGet.org source URL, and `--skip-duplicate` behavior.