### PR TITLE
Add actions read permission to NuGet release job

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -275,7 +275,7 @@ jobs:
         id: login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         with:
-          user: ${{ secrets.NUGET_USER }}
+          user: jfversluis_MSFT
 
       - name: Push to NuGet.org
         run: >

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -254,6 +254,7 @@ jobs:
     environment: nuget-release-gate # This gates this job until manually approved
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       id-token: write
       contents: read
 


### PR DESCRIPTION
## Release blocker

**Merging this PR is mandatory before the next release.** Without this change, NuGet trusted publishing will fail at the `NuGet/login` step because no `NUGET_USER` environment secret will be present.

## Summary

- Add `actions: read` to the NuGet.org `release` job permissions alongside `id-token: write` and `contents: read`.
- Use the literal public NuGet username `jfversluis_MSFT` for `NuGet/login` instead of a hidden secret.
- OIDC still provides the short-lived API key through `${{ steps.login.outputs.NUGET_API_KEY }}`; the username itself is public.
- Align the Maui.Markup trusted-publishing job with the CommunityToolkit/Maui fix.
- This is needed because `actions/download-artifact` requires `actions: read` when job permissions are explicitly restricted.
- The NuGet.org trusted publishing configuration is already taken care of.

## Validation

- `git diff --check`
- Text check confirmed the `release` job includes `actions: read`, `id-token: write`, and `contents: read`.
- Text check confirmed `NuGet/login` uses `user: jfversluis_MSFT` and no longer references `${{ secrets.NUGET_USER }}`.
- Text check confirmed NuGet push still uses `${{ steps.login.outputs.NUGET_API_KEY }}`.